### PR TITLE
llvm-hs 5.1.0: Cabal >= 2.1 compatibility

### DIFF
--- a/patches/llvm-hs-5.1.0.patch
+++ b/patches/llvm-hs-5.1.0.patch
@@ -1,0 +1,25 @@
+diff --git llvm-hs/Setup.hs llvm-hs/Setup.hs
+index fe7daf4..7bf1729 100644
+--- llvm-hs/Setup.hs
++++ llvm-hs/Setup.hs
+@@ -35,6 +35,11 @@ mkFlagName :: String -> FlagName
+ mkFlagName = FlagName
+ #endif
+ 
++#if !MIN_VERSION_Cabal(2,1,0)
++lookupFlagAssignment :: FlagName -> FlagAssignment -> Maybe Bool
++lookupFlagAssignment = lookup
++#endif
++
+ llvmVersion :: Version
+ llvmVersion = mkVersion [5,0]
+ 
+@@ -125,7 +130,7 @@ main = do
+       [llvmVersion] <- liftM lines $ llvmConfig ["--version"]
+       let getLibs = liftM (map (fromJust . stripPrefix "-l") . words) . llvmConfig
+           flags    = configConfigurationsFlags confFlags
+-          linkFlag = case lookup (mkFlagName "shared-llvm") flags of
++          linkFlag = case lookupFlagAssignment (mkFlagName "shared-llvm") flags of
+                        Nothing     -> "--link-shared"
+                        Just shared -> if shared then "--link-shared" else "--link-static"
+       libs       <- getLibs ["--libs", linkFlag]


### PR DESCRIPTION
llvm-hs uses a custom `Setup.hs` which needs to be adapted to the recent `FlagAssignment` change in cabal.