### PR TITLE
Hide Div / Mod from GHC.TypeLits

### DIFF
--- a/patches/constraints-0.9.1.patch
+++ b/patches/constraints-0.9.1.patch
@@ -1,23 +1,7 @@
-From c1f7c8c6a5a620824d72c34103c7fcafb0cc8f66 Mon Sep 17 00:00:00 2001
-From: Ryan Scott <ryan.gl.scott@gmail.com>
-Date: Fri, 8 Sep 2017 18:49:00 -0400
-Subject: [PATCH] Adapt to the Semigroup-Monoid Proposal (#65)
-
-* Adapt to the Semigroup-Monoid Proposal
-
-* Delete unneeded (and problematic) import
----
- CHANGELOG.markdown             |  6 ++++++
- constraints.cabal              |  1 +
- src/Data/Constraint.hs         | 33 +++++++++++++++++++++++++++------
- src/Data/Constraint/Lifting.hs | 10 ++++++++--
- 4 files changed, 42 insertions(+), 8 deletions(-)
-
-diff --git a/constraints.cabal b/constraints.cabal
-index f1f49c5..0583067 100644
---- a/constraints.cabal
-+++ b/constraints.cabal
-@@ -48,6 +48,7 @@ library
+diff -ru constraints-0.9.1.orig/constraints.cabal constraints-0.9.1/constraints.cabal
+--- constraints-0.9.1.orig/constraints.cabal	2017-12-11 14:15:15.576563032 +0000
++++ constraints-0.9.1/constraints.cabal	2017-12-11 14:25:10.160619151 +0000
+@@ -48,6 +48,7 @@
      ghc-prim,
      hashable >= 1.2 && < 1.3,
      mtl >= 2 && < 2.3,
@@ -25,24 +9,68 @@ index f1f49c5..0583067 100644
      transformers >= 0.2 && < 0.6,
      transformers-compat >= 0.4 && < 1
  
-diff --git a/src/Data/Constraint.hs b/src/Data/Constraint.hs
-index b975069..ea50ce1 100644
---- a/src/Data/Constraint.hs
-+++ b/src/Data/Constraint.hs
-@@ -77,11 +77,9 @@ import Control.Applicative
- import Control.Category
- import Control.DeepSeq
- import Control.Monad
--#if __GLASGOW_HASKELL__ < 710
--import Data.Monoid
--#endif
- import Data.Complex
+diff -ru constraints-0.9.1.orig/src/Data/Constraint/Lifting.hs constraints-0.9.1/src/Data/Constraint/Lifting.hs
+--- constraints-0.9.1.orig/src/Data/Constraint/Lifting.hs	2017-12-11 15:07:37.023705859 +0000
++++ constraints-0.9.1/src/Data/Constraint/Lifting.hs	2017-12-11 15:07:45.991476779 +0000
+@@ -54,6 +54,9 @@
+ import Data.Monoid
+ #endif
  import Data.Ratio
++#if !(MIN_VERSION_base(4,11,0))
 +import Data.Semigroup
- import Data.Data
- import qualified GHC.Exts as Exts (Any)
- import GHC.Exts (Constraint)
-@@ -625,8 +623,27 @@ instance RealFloat a :=> RealFloat (Identity a) where ins = Sub Dict
++#endif
+ #if __GLASGOW_HASKELL__ < 710
+ import Data.Traversable
+ #endif
+@@ -77,6 +80,7 @@
+ instance Lifting Hashable Maybe where lifting = Sub Dict
+ instance Lifting Binary Maybe where lifting = Sub Dict
+ instance Lifting NFData Maybe where lifting = Sub Dict
++instance Lifting Semigroup Maybe where lifting = Sub Dict
+ instance Lifting Monoid Maybe where lifting = Sub Dict
+ 
+ instance Lifting Eq Ratio where lifting = Sub Dict
+@@ -85,7 +89,7 @@
+ instance Lifting Eq Complex where lifting = Sub Dict
+ instance Lifting Read Complex where lifting = Sub Dict
+ instance Lifting Show Complex where lifting = Sub Dict
+-
++instance Lifting Semigroup ((->) a) where lifting = Sub Dict
+ instance Lifting Monoid ((->) a) where lifting = Sub Dict
+ 
+ instance Eq a => Lifting Eq (Either a) where lifting = Sub Dict
+@@ -103,6 +107,7 @@
+ instance Hashable a => Lifting Hashable ((,) a) where lifting = Sub Dict
+ instance Binary a => Lifting Binary ((,) a) where lifting = Sub Dict
+ instance NFData a => Lifting NFData ((,) a) where lifting = Sub Dict
++instance Semigroup a => Lifting Semigroup ((,) a) where lifting = Sub Dict
+ instance Monoid a => Lifting Monoid ((,) a) where lifting = Sub Dict
+ instance Bounded a => Lifting Bounded ((,) a) where lifting = Sub Dict
+ instance Ix a => Lifting Ix ((,) a) where lifting = Sub Dict
+@@ -434,6 +439,7 @@
+ instance Lifting2 Hashable (,) where lifting2 = Sub Dict
+ instance Lifting2 Binary (,) where lifting2 = Sub Dict
+ instance Lifting2 NFData (,) where lifting2 = Sub Dict
++instance Lifting2 Semigroup (,) where lifting2 = Sub Dict
+ instance Lifting2 Monoid (,) where lifting2 = Sub Dict
+ instance Lifting2 Bounded (,) where lifting2 = Sub Dict
+ instance Lifting2 Ix (,) where lifting2 = Sub Dict
+diff -ru constraints-0.9.1.orig/src/Data/Constraint/Nat.hs constraints-0.9.1/src/Data/Constraint/Nat.hs
+--- constraints-0.9.1.orig/src/Data/Constraint/Nat.hs	2017-03-13 14:35:11.000000000 +0000
++++ constraints-0.9.1/src/Data/Constraint/Nat.hs	2017-12-11 14:27:39.277908760 +0000
+@@ -42,7 +42,7 @@
+ 
+ import Data.Constraint
+ import Data.Proxy
+-import GHC.TypeLits
++import GHC.TypeLits hiding (type Div, type Mod)
+ import Unsafe.Coerce
+ 
+ type family Min :: Nat -> Nat -> Nat where
+diff -ru constraints-0.9.1.orig/src/Data/Constraint.hs constraints-0.9.1/src/Data/Constraint.hs
+--- constraints-0.9.1.orig/src/Data/Constraint.hs	2017-03-13 14:35:11.000000000 +0000
++++ constraints-0.9.1/src/Data/Constraint.hs	2017-12-11 14:25:10.160619151 +0000
+@@ -618,8 +618,27 @@
  instance RealFloat a :=> RealFloat (Const a b) where ins = Sub Dict
  #endif
  
@@ -70,7 +98,7 @@ index b975069..ea50ce1 100644
  instance () :=> Monoid () where ins = Sub Dict
  instance () :=> Monoid Ordering where ins = Sub Dict
  instance () :=> Monoid [a] where ins = Sub Dict
-@@ -635,8 +652,6 @@ instance (Monoid a, Monoid b) :=> Monoid (a, b) where ins = Sub Dict
+@@ -628,8 +647,6 @@
  instance Monoid a :=> Monoid (Const a b) where ins = Sub Dict
  #if MIN_VERSION_base(4,9,0)
  instance Monoid a :=> Monoid (Identity a) where ins = Sub Dict
@@ -79,7 +107,7 @@ index b975069..ea50ce1 100644
  instance Monoid a :=> Monoid (IO a) where ins = Sub Dict
  #endif
  
-@@ -707,7 +722,13 @@ instance a => Bounded (Dict a) where
+@@ -700,7 +717,13 @@
  instance a :=> Read (Dict a) where ins = Sub Dict
  deriving instance a => Read (Dict a)
  
@@ -94,59 +122,3 @@ index b975069..ea50ce1 100644
 +  mappend = (<>)
 +#endif
    mempty = Dict
-diff --git a/src/Data/Constraint/Lifting.hs b/src/Data/Constraint/Lifting.hs
-index d37d7ec..30f2159 100644
---- a/src/Data/Constraint/Lifting.hs
-+++ b/src/Data/Constraint/Lifting.hs
-@@ -9,7 +9,7 @@
- {-# LANGUAGE MultiParamTypeClasses #-}
- {-# LANGUAGE PolyKinds #-}
- {-# OPTIONS_GHC -fno-warn-deprecations #-}
--module Data.Constraint.Lifting 
-+module Data.Constraint.Lifting
-   ( Lifting(..)
-   , Lifting2(..)
-   ) where
-@@ -54,6 +54,9 @@ import Data.Hashable
- import Data.Monoid
- #endif
- import Data.Ratio
-+#if !(MIN_VERSION_base(4,11,0))
-+import Data.Semigroup
-+#endif
- #if __GLASGOW_HASKELL__ < 710
- import Data.Traversable
- #endif
-@@ -77,6 +80,7 @@ instance Lifting Read Maybe where lifting = Sub Dict
- instance Lifting Hashable Maybe where lifting = Sub Dict
- instance Lifting Binary Maybe where lifting = Sub Dict
- instance Lifting NFData Maybe where lifting = Sub Dict
-+instance Lifting Semigroup Maybe where lifting = Sub Dict
- instance Lifting Monoid Maybe where lifting = Sub Dict
- 
- instance Lifting Eq Ratio where lifting = Sub Dict
-@@ -85,7 +89,7 @@ instance Lifting Eq Ratio where lifting = Sub Dict
- instance Lifting Eq Complex where lifting = Sub Dict
- instance Lifting Read Complex where lifting = Sub Dict
- instance Lifting Show Complex where lifting = Sub Dict
--
-+instance Lifting Semigroup ((->) a) where lifting = Sub Dict
- instance Lifting Monoid ((->) a) where lifting = Sub Dict
- 
- instance Eq a => Lifting Eq (Either a) where lifting = Sub Dict
-@@ -103,6 +107,7 @@ instance Read a => Lifting Read ((,) a) where lifting = Sub Dict
- instance Hashable a => Lifting Hashable ((,) a) where lifting = Sub Dict
- instance Binary a => Lifting Binary ((,) a) where lifting = Sub Dict
- instance NFData a => Lifting NFData ((,) a) where lifting = Sub Dict
-+instance Semigroup a => Lifting Semigroup ((,) a) where lifting = Sub Dict
- instance Monoid a => Lifting Monoid ((,) a) where lifting = Sub Dict
- instance Bounded a => Lifting Bounded ((,) a) where lifting = Sub Dict
- instance Ix a => Lifting Ix ((,) a) where lifting = Sub Dict
-@@ -434,6 +439,7 @@ instance Lifting2 Read (,) where lifting2 = Sub Dict
- instance Lifting2 Hashable (,) where lifting2 = Sub Dict
- instance Lifting2 Binary (,) where lifting2 = Sub Dict
- instance Lifting2 NFData (,) where lifting2 = Sub Dict
-+instance Lifting2 Semigroup (,) where lifting2 = Sub Dict
- instance Lifting2 Monoid (,) where lifting2 = Sub Dict
- instance Lifting2 Bounded (,) where lifting2 = Sub Dict
- instance Lifting2 Ix (,) where lifting2 = Sub Dict

--- a/patches/constraints-0.9.1.patch
+++ b/patches/constraints-0.9.1.patch
@@ -1,6 +1,6 @@
 diff -ru constraints-0.9.1.orig/constraints.cabal constraints-0.9.1/constraints.cabal
---- constraints-0.9.1.orig/constraints.cabal	2017-12-11 14:15:15.576563032 +0000
-+++ constraints-0.9.1/constraints.cabal	2017-12-11 14:25:10.160619151 +0000
+--- constraints-0.9.1.orig/constraints.cabal	2017-12-14 16:01:10.333221877 +0000
++++ constraints-0.9.1/constraints.cabal	2017-12-14 16:01:51.188356699 +0000
 @@ -48,6 +48,7 @@
      ghc-prim,
      hashable >= 1.2 && < 1.3,
@@ -10,8 +10,8 @@ diff -ru constraints-0.9.1.orig/constraints.cabal constraints-0.9.1/constraints.
      transformers-compat >= 0.4 && < 1
  
 diff -ru constraints-0.9.1.orig/src/Data/Constraint/Lifting.hs constraints-0.9.1/src/Data/Constraint/Lifting.hs
---- constraints-0.9.1.orig/src/Data/Constraint/Lifting.hs	2017-12-11 15:07:37.023705859 +0000
-+++ constraints-0.9.1/src/Data/Constraint/Lifting.hs	2017-12-11 15:07:45.991476779 +0000
+--- constraints-0.9.1.orig/src/Data/Constraint/Lifting.hs	2017-03-13 14:35:11.000000000 +0000
++++ constraints-0.9.1/src/Data/Constraint/Lifting.hs	2017-12-14 16:01:51.188356699 +0000
 @@ -54,6 +54,9 @@
  import Data.Monoid
  #endif
@@ -57,19 +57,42 @@ diff -ru constraints-0.9.1.orig/src/Data/Constraint/Lifting.hs constraints-0.9.1
  instance Lifting2 Ix (,) where lifting2 = Sub Dict
 diff -ru constraints-0.9.1.orig/src/Data/Constraint/Nat.hs constraints-0.9.1/src/Data/Constraint/Nat.hs
 --- constraints-0.9.1.orig/src/Data/Constraint/Nat.hs	2017-03-13 14:35:11.000000000 +0000
-+++ constraints-0.9.1/src/Data/Constraint/Nat.hs	2017-12-11 14:27:39.277908760 +0000
-@@ -42,7 +42,7 @@
++++ constraints-0.9.1/src/Data/Constraint/Nat.hs	2017-12-14 16:05:49.260898238 +0000
+@@ -1,3 +1,4 @@
++{-# LANGUAGE CPP #-}
+ {-# LANGUAGE DataKinds #-}
+ {-# LANGUAGE PolyKinds #-}
+ {-# LANGUAGE RankNTypes #-}
+@@ -42,7 +43,11 @@
  
  import Data.Constraint
  import Data.Proxy
--import GHC.TypeLits
++#if __GLASGOW_HASKELL__ > 802
 +import GHC.TypeLits hiding (type Div, type Mod)
++#else
+ import GHC.TypeLits
++#endif
  import Unsafe.Coerce
  
  type family Min :: Nat -> Nat -> Nat where
 diff -ru constraints-0.9.1.orig/src/Data/Constraint.hs constraints-0.9.1/src/Data/Constraint.hs
 --- constraints-0.9.1.orig/src/Data/Constraint.hs	2017-03-13 14:35:11.000000000 +0000
-+++ constraints-0.9.1/src/Data/Constraint.hs	2017-12-11 14:25:10.160619151 +0000
++++ constraints-0.9.1/src/Data/Constraint.hs	2017-12-14 16:08:52.823606547 +0000
+@@ -76,11 +76,11 @@
+ import Control.Applicative
+ import Control.Category
+ import Control.Monad
+-#if __GLASGOW_HASKELL__ < 710
+-import Data.Monoid
+-#endif
+ import Data.Complex
+ import Data.Ratio
++#if __GLASGOW_HASKELL__ <= 802
++import Data.Semigroup
++#endif
+ import Data.Data
+ import qualified GHC.Exts as Exts (Any)
+ import GHC.Exts (Constraint)
 @@ -618,8 +618,27 @@
  instance RealFloat a :=> RealFloat (Const a b) where ins = Sub Dict
  #endif


### PR DESCRIPTION
`GHC.TypeLits` recently added `Div` and `Mod` which interfere with `Data.Constraints.Nat`, this commit hides them from the import.