### PR TITLE
Add patches for criterion, haskell-src-exts, and simple-reflect

### DIFF
--- a/patches/criterion-1.2.6.0.patch
+++ b/patches/criterion-1.2.6.0.patch
@@ -1,0 +1,110 @@
+commit dd847e8d29133f5a5c420e728023f92e2023c283
+Author: Ryan Scott <ryan.gl.scott@gmail.com>
+Date:   Thu Dec 28 11:21:03 2017 -0500
+
+    Remove deprecated GCStats-based interface
+
+    Fixes #171.
+
+diff --git a/Criterion/Measurement.hs b/Criterion/Measurement.hs
+index d352bf6..d006933 100644
+--- a/Criterion/Measurement.hs
++++ b/Criterion/Measurement.hs
+@@ -5,12 +5,6 @@
+ {-# LANGUAGE BangPatterns, CPP, ForeignFunctionInterface,
+     ScopedTypeVariables #-}
+
+-#if MIN_VERSION_base(4,10,0)
+--- Disable deprecation warnings for now until we remove the use of getGCStats
+--- and applyGCStats for good
+-{-# OPTIONS_GHC -Wno-deprecations #-}
+-#endif
+-
+ -- |
+ -- Module      : Criterion.Measurement
+ -- Copyright   : (c) 2009-2014 Bryan O'Sullivan
+@@ -38,9 +32,6 @@ module Criterion.Measurement
+     , measured
+     , applyGCStatistics
+     , threshold
+-      -- * Deprecated
+-    , getGCStats
+-    , applyGCStats
+     ) where
+
+ import Criterion.Types (Benchmarkable(..), Measured(..))
+@@ -52,9 +43,10 @@ import Data.Int (Int64)
+ import Data.List (unfoldr)
+ import Data.Word (Word64)
+ import GHC.Generics (Generic)
+-import GHC.Stats (GCStats(..))
+ #if MIN_VERSION_base(4,10,0)
+ import GHC.Stats (RTSStats(..), GCDetails(..))
++#else
++import GHC.Stats (GCStats(..))
+ #endif
+ import System.Mem (performGC)
+ import Text.Printf (printf)
+@@ -66,9 +58,9 @@ import qualified GHC.Stats as Stats
+ -- 'gcStatsCurrentBytesUsed' and 'gcStatsCurrentBytesSlop' all are cumulative values since
+ -- the program started.
+ --
+--- 'GCStatistics' is cargo-culted from the 'GCStats' data type that "GHC.Stats"
+--- has. Since 'GCStats' was marked as deprecated and will be removed in GHC 8.4,
+--- we use 'GCStatistics' to provide a backwards-compatible view of GC statistics.
++-- 'GCStatistics' is cargo-culted from the @GCStats@ data type that "GHC.Stats"
++-- used to export. Since @GCStats@ was removed in GHC 8.4, @criterion@ uses
++-- 'GCStatistics' to provide a backwards-compatible view of GC statistics.
+ data GCStatistics = GCStatistics
+     { -- | Total number of bytes allocated
+     gcStatsBytesAllocated :: !Int64
+@@ -115,18 +107,6 @@ data GCStatistics = GCStatistics
+ -- | Try to get GC statistics, bearing in mind that the GHC runtime
+ -- will throw an exception if statistics collection was not enabled
+ -- using \"@+RTS -T@\".
+-{-# DEPRECATED getGCStats
+-      ["GCStats has been deprecated in GHC 8.2. As a consequence,",
+-       "getGCStats has also been deprecated in favor of getGCStatistics.",
+-       "getGCStats will be removed in the next major criterion release."] #-}
+-getGCStats :: IO (Maybe GCStats)
+-getGCStats =
+-  (Just `fmap` Stats.getGCStats) `Exc.catch` \(_::Exc.SomeException) ->
+-  return Nothing
+-
+--- | Try to get GC statistics, bearing in mind that the GHC runtime
+--- will throw an exception if statistics collection was not enabled
+--- using \"@+RTS -T@\".
+ getGCStatistics :: IO (Maybe GCStatistics)
+ #if MIN_VERSION_base(4,10,0)
+ -- Use RTSStats/GCDetails to gather GC stats
+@@ -331,30 +311,6 @@ measured = Measured {
+
+ -- | Apply the difference between two sets of GC statistics to a
+ -- measurement.
+-{-# DEPRECATED applyGCStats
+-      ["GCStats has been deprecated in GHC 8.2. As a consequence,",
+-       "applyGCStats has also been deprecated in favor of applyGCStatistics.",
+-       "applyGCStats will be removed in the next major criterion release."] #-}
+-applyGCStats :: Maybe GCStats
+-             -- ^ Statistics gathered at the __end__ of a run.
+-             -> Maybe GCStats
+-             -- ^ Statistics gathered at the __beginning__ of a run.
+-             -> Measured
+-             -- ^ Value to \"modify\".
+-             -> Measured
+-applyGCStats (Just end) (Just start) m = m {
+-    measAllocated          = diff bytesAllocated
+-  , measNumGcs             = diff numGcs
+-  , measBytesCopied        = diff bytesCopied
+-  , measMutatorWallSeconds = diff mutatorWallSeconds
+-  , measMutatorCpuSeconds  = diff mutatorCpuSeconds
+-  , measGcWallSeconds      = diff gcWallSeconds
+-  , measGcCpuSeconds       = diff gcCpuSeconds
+-  } where diff f = f end - f start
+-applyGCStats _ _ m = m
+-
+--- | Apply the difference between two sets of GC statistics to a
+--- measurement.
+ applyGCStatistics :: Maybe GCStatistics
+                   -- ^ Statistics gathered at the __end__ of a run.
+                   -> Maybe GCStatistics

--- a/patches/haskell-src-exts-1.20.1.patch
+++ b/patches/haskell-src-exts-1.20.1.patch
@@ -1,0 +1,91 @@
+commit f1ab604faf30672af3581ed1370c8d88d7ebf28f
+Author: Ryan Scott <ryan.gl.scott@gmail.com>
+Date:   Thu Dec 28 12:02:29 2017 -0500
+
+    Adapt to the Semigroup–Monoid Proposal
+
+diff --git a/src/Language/Haskell/Exts/InternalParser.ly b/src/Language/Haskell/Exts/InternalParse
+index ee20f64..8a8ea96 100644
+--- a/src/Language/Haskell/Exts/InternalParser.ly
++++ b/src/Language/Haskell/Exts/InternalParser.ly
+@@ -1,4 +1,5 @@
+ > {
++> {-# LANGUAGE CPP #-}
+ > {-# OPTIONS_HADDOCK hide #-}
+ > -----------------------------------------------------------------------------
+ > -- |
+@@ -40,6 +41,9 @@
+ > import Control.Monad ( liftM, (<=<), when )
+ > import Control.Applicative ( (<$>) )
+ > import Data.Maybe
++> #if MIN_VERSION_base(4,11,0)
++> import Prelude hiding ((<>))
++> #endif
+ import Debug.Trace (trace)
+
+ > }
+diff --git a/src/Language/Haskell/Exts/ParseMonad.hs b/src/Language/Haskell/Exts/ParseMonad.hs
+index bc77eb5..209e76b 100644
+--- a/src/Language/Haskell/Exts/ParseMonad.hs
++++ b/src/Language/Haskell/Exts/ParseMonad.hs
+@@ -1,3 +1,4 @@
++{-# LANGUAGE CPP #-}
+ {-# OPTIONS_HADDOCK hide #-}
+ -----------------------------------------------------------------------------
+ -- |
+@@ -45,7 +46,10 @@ import Language.Haskell.Exts.Extension -- (Extension, impliesExts, haskell2010)
+ import Data.List (intercalate)
+ import Control.Applicative
+ import Control.Monad (when, liftM, ap)
+-import Data.Monoid
++import Data.Monoid hiding ((<>))
++#if MIN_VERSION_base(4,9,0)
++import Data.Semigroup
++#endif
+ -- To avoid import warnings for Control.Applicative and Data.Monoid
+ import Prelude
+
+@@ -98,12 +102,24 @@ instance Monad ParseResult where
+   ParseOk x           >>= f = f x
+   ParseFailed loc msg >>= _ = ParseFailed loc msg
+
+-instance Monoid m => Monoid (ParseResult m) where
++#if MIN_VERSION_base(4,9,0)
++instance Semigroup m => Semigroup (ParseResult m) where
++ ParseOk x <> ParseOk y = ParseOk $ x <> y
++ ParseOk _ <> err       = err
++ err       <> _         = err -- left-biased
++#endif
++
++instance ( Monoid m
++#if MIN_VERSION_base(4,9,0) && !(MIN_VERSION_base(4,11,0))
++         , Semigroup m
++#endif
++         ) => Monoid (ParseResult m) where
+   mempty = ParseOk mempty
++#if !(MIN_VERSION_base(4,11,0))
+   ParseOk x `mappend` ParseOk y = ParseOk $ x `mappend` y
+   ParseOk _ `mappend` err       = err
+   err       `mappend` _         = err -- left-biased
+-
++#endif
+
+ -- internal version
+ data ParseStatus a = Ok ParseState a | Failed SrcLoc String
+diff --git a/src/Language/Haskell/Exts/Pretty.hs b/src/Language/Haskell/Exts/Pretty.hs
+index c03e438..adced3f 100644
+--- a/src/Language/Haskell/Exts/Pretty.hs
++++ b/src/Language/Haskell/Exts/Pretty.hs
+@@ -31,7 +31,11 @@ import qualified Language.Haskell.Exts.ParseSyntax as P
+
+ import Language.Haskell.Exts.SrcLoc hiding (loc)
+
+-import Prelude hiding (exp)
++import Prelude hiding ( exp
++#if MIN_VERSION_base(4,11,0)
++                      , (<>)
++#endif
++                      )
+ import qualified Text.PrettyPrint as P
+ import Data.List (intersperse)
+ import Data.Maybe (isJust , fromMaybe)

--- a/patches/simple-reflect-0.3.2.patch
+++ b/patches/simple-reflect-0.3.2.patch
@@ -1,0 +1,34 @@
+diff -ru simple-reflect-0.3.2.orig/Debug/SimpleReflect/Expr.hs simple-reflect-0.3.2/Debug/SimpleReflect/Expr.hs
+--- simple-reflect-0.3.2.orig/Debug/SimpleReflect/Expr.hs	2014-04-15 09:49:59.000000000 -0400
++++ simple-reflect-0.3.2/Debug/SimpleReflect/Expr.hs	2017-12-28 12:24:08.448750835 -0500
+@@ -1,3 +1,4 @@
++{-# LANGUAGE CPP #-}
+ -----------------------------------------------------------------------------
+ -- |
+ -- Module      :  Debug.SimpleReflect.Expr
+@@ -22,6 +23,9 @@
+ 
+ import Data.List
+ import Data.Monoid
++#if MIN_VERSION_base(4,9,0) && !(MIN_VERSION_base(4,11,0))
++import Data.Semigroup
++#endif
+ import Control.Applicative
+ 
+ ------------------------------------------------------------------------------
+@@ -220,8 +224,15 @@
+ -- Other classes
+ ------------------------------------------------------------------------------
+ 
++#if MIN_VERSION_base(4,9,0)
++instance Semigroup Expr where
++    (<>) = withReduce2 $ op InfixR 6 " <> "
++#endif
++
+ instance Monoid Expr where
+     mempty = var "mempty"
++#if !(MIN_VERSION_base(4,11,0))
+     mappend = withReduce2 $ op InfixR 6 " <> "
++#endif
+     mconcat = fun "mconcat"
+ 


### PR DESCRIPTION
I needed these when trying to build `lens`'s test suite and benchmarks on GHC 8.4.