### PR TITLE
Add instructions and scripts for using the repo on nix

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,12 +1,12 @@
 # Using the nix overrides
 
 The most convenient way to use the nix script is to make a new top level
-attribute for the
+attribute for the overriden package set.
 
 I achieve this using an overlay.
 
 `~/.config/nixpkgs/overlays.nix` contains a list of overlays which augment the
-main package set.
+main package set. I just have one which I keep in my home directory for convenience.
 
 ```
 [ (import ~/overlay.nix) ]
@@ -19,7 +19,7 @@ self: super:
 {
   # An attribute which contains the head overrides.
   patches = super.callPackage <local-path-to-overrides.nix>
-              { patches = <path-to-path-folder>; };
+              { patches = <path-to-patch-folder>; };
 
 
   # A modified package set intented to be used with ghcHEAD

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,55 @@
+# Using the nix overrides
+
+The most convenient way to use the nix script is to make a new top level
+attribute for the
+
+I achieve this using an overlay.
+
+`~/.config/nixpkgs/overlays.nix` contains a list of overlays which augment the
+main package set.
+
+```
+[ (import ~/overlay.nix) ]
+```
+
+Then in `~/overlay.nix`, I define a new attribute which contains the patch overrides.
+
+```nix
+self: super:
+{
+  # An attribute which contains the head overrides.
+  patches = super.callPackage <local-path-to-overrides.nix>
+              { patches = <path-to-path-folder>; };
+
+
+  # A modified package set intented to be used with ghcHEAD
+  ghcHEAD = super.haskell.packages.ghcHEAD.override
+  { overrides = sel: sup:
+                  # The patches from the directory
+                  ((super.callPackage self.patches {} sel sup)
+                  # Any more local overrides you want.
+                  // { mkDerivation = drv: sup.mkDerivation
+                        ( drv // { jailbreak = true; doHaddock = false; });
+                        generic-deriving = super.haskell.lib.dontCheck sup.generic-deriving;
+                       });
+                   };
+}
+```
+
+The `patches` attribute is the file which `generate-nix-overrides.hs` creates.
+You need to set the correct paths to `overrides.nix` and the patch folder.
+
+For example, if you have cloned `head.hackage` into your home directory, you would
+set them to `~/head.hackage/scripts/overrides.nix` and `~/head.hackage/patches`
+respectively. Having a local installation is desirable as when using `head.hackage`
+you have to commonly add new patches to `patches`.
+
+Once you have setup this overlay, you can test your new attribute by trying to build
+a package.
+
+```
+nix-shell -p "ghcHEAD.ghcWithPackages (ps: [ps.primitive])"
+```
+
+and it might work, or it might not :). If it doesn't work, add a patch to your
+patches directory and try again.

--- a/scripts/generate-nix-overrides.hs
+++ b/scripts/generate-nix-overrides.hs
@@ -1,0 +1,63 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i runghc -p "haskellPackages.ghcWithPackages (ps: [ps.hopenssl ps.distribution-nixpkgs])"
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+import Data.List
+import Distribution.Package
+import Distribution.Text
+import Distribution.Version
+import System.Directory
+import System.Environment
+import System.FilePath
+import qualified Data.Map as Map
+import Data.Ord
+
+groupPatches :: Ord a => [(a, k)] -> [(a, [k])]
+groupPatches assocs = Map.toAscList $ Map.fromListWith (++) [(k, [v]) | (k, v) <- assocs]
+
+generateOverrides :: FilePath -> FilePath -> IO String
+generateOverrides prefix patchDir = do
+  patches <- listDirectory patchDir
+  override_groups <- groupPatches <$> mapM (generateOverride prefix patchDir) patches
+  let overrides = map mkOverride override_groups
+  return $ intercalate "\n" overrides
+
+mkOverride :: (PackageName, [([Int], String)]) -> String
+mkOverride (display -> pName, patches) =
+  unlines $
+    [unwords [pName, "= if false then", superPname]]
+     ++ packages ++
+    [ "else", superPname, ";"]
+  where
+    superPname = "super." ++ pName
+    quotes s = "\"" ++ s ++ "\""
+    packages :: [String]
+    packages = map mkPackages (sortBy (comparing fst) patches)
+    mkPackages (version, patch) =
+      unwords ["else if", superPname ++ ".version == "
+                        ,  quotes (intercalate "." (map show version))
+                        ," then (", patch, ")"]
+
+
+generateOverride :: FilePath -> FilePath -> FilePath -> IO (PackageName, ([Int], String))
+generateOverride prefix patchDir patch = do
+  let pid' :: Maybe PackageId  = simpleParse (takeBaseName patch)
+  pid <- maybe (fail ("invalid patch file name: " ++ show patch)) return pid'
+  let pname = display (packageName pid)
+      version = versionNumbers (packageVersion pid)
+  return $ (packageName pid, (version,
+    unwords [ "haskell.lib.appendPatch", "super."++pname, prefix </> patchDir </> patch ]))
+
+main :: IO ()
+main = do
+  args <- getArgs
+  (prefix, patchDir) <- case args of
+                []    -> return ("", "patches")
+                [dir] -> return ("", dir)
+                [prefix, dir] -> return (prefix, dir)
+                _     -> fail "Usage: generate-nix-overrides [<prefix>, patchdir]"
+  overrides <- generateOverrides prefix patchDir
+  putStrLn "{haskell}: self: super: {\n"
+  putStrLn overrides
+  putStrLn "}"

--- a/scripts/generate-nix-overrides.hs
+++ b/scripts/generate-nix-overrides.hs
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i runghc -p "haskellPackages.ghcWithPackages (ps: [ps.hopenssl ps.distribution-nixpkgs])"
+#! nix-shell -i runghc -p "haskellPackages.ghcWithPackages (ps: [])"
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 

--- a/scripts/overrides.nix
+++ b/scripts/overrides.nix
@@ -1,0 +1,42 @@
+{ stdenv
+  , haskell
+  , patches  # A directory containing patch files used to build packages
+             # it can either be a local directory or fetched from the web
+}:
+let
+  ghc = haskell.packages.ghc822.ghcWithPackages (ps: with ps;
+        [ ps.hopenssl ps.distribution-nixpkgs
+        ]);
+in
+
+stdenv.mkDerivation {
+
+  name = "hs-generate-overrides-0.1";
+
+  src = ./generate-nix-overrides.hs;
+
+  preUnpack = ''mkdir hs-generate-overrides'';
+  buildInputs = [ ghc ];
+
+  unpackCmd = ''
+    cp $curSrc ./hs-generate-overrides
+    cp -r ${patches} ./hs-generate-overrides/patches
+    sourceRoot=hs-generate-overrides;
+  '';
+
+  buildPhase = ''
+    ghc $src -o generate
+    ./generate $script/patches patches > patches.nix
+  '';
+
+  outputs = ["out" "script"];
+
+  installPhase = ''
+    cp patches.nix $out
+    ensureDir $script/patches
+    cp -r patches $script/patches
+  '';
+
+}
+
+


### PR DESCRIPTION
This is a modified version of the script originally written by @peti and requested by @bgamari.

There are a few changes

1. Patches are fetched once when the overrides are generated and stored in the nix-store rather than from the github repo. This allows the source of the patches to be more flexible.
2. I added a wrapper which builds the `patches.nix` file for you so you can just add a patch to `patches` and it will regenerate the overrides. 
  