### PR TITLE
Add patches for conduit, haskell-src-exts-util, and streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,4 +107,4 @@ TODO: implement script
 
 ### Travis CI
 
-The [Travis CI script generator](https://github.com/haskell-hvr/multi-ghc-travis) has recently added support for enabling the `HEAD.hackage` repository automatically for jobs uisng unreleased GHC versions.
+The [Travis CI script generator](https://github.com/haskell-hvr/multi-ghc-travis) has recently added support for enabling the `HEAD.hackage` repository automatically for jobs using unreleased GHC versions.

--- a/scripts/conduit-1.2.12.1.patch
+++ b/scripts/conduit-1.2.12.1.patch
@@ -1,0 +1,107 @@
+diff -ru conduit-1.2.12.1.orig/conduit.cabal conduit-1.2.12.1/conduit.cabal
+--- conduit-1.2.12.1.orig/conduit.cabal	2018-01-06 17:22:28.828784258 -0500
++++ conduit-1.2.12.1/conduit.cabal	2018-01-06 17:26:05.524789715 -0500
+@@ -37,6 +37,7 @@
+                      , resourcet                >= 1.1          && < 1.2
+                      , exceptions               >= 0.6
+                      , lifted-base              >= 0.1
++                     , semigroups               >= 0.16
+                      , transformers-base        >= 0.4.1        && < 0.5
+                      , transformers             >= 0.2.2
+                      , transformers-compat      >= 0.3
+@@ -60,6 +61,7 @@
+                    , base
+                    , hspec >= 1.3
+                    , QuickCheck >= 2.7
++                   , semigroups >= 0.16
+                    , transformers
+                    , mtl
+                    , resourcet
+diff -ru conduit-1.2.12.1.orig/Data/Conduit/Internal/Conduit.hs conduit-1.2.12.1/Data/Conduit/Internal/Conduit.hs
+--- conduit-1.2.12.1.orig/Data/Conduit/Internal/Conduit.hs	2017-09-25 03:19:47.000000000 -0400
++++ conduit-1.2.12.1/Data/Conduit/Internal/Conduit.hs	2018-01-06 17:27:20.360791600 -0500
+@@ -102,6 +102,7 @@
+ import Control.Monad.Primitive (PrimMonad, PrimState, primitive)
+ import Data.Void (Void, absurd)
+ import Data.Monoid (Monoid (mappend, mempty))
++import Data.Semigroup (Semigroup ((<>)))
+ import Control.Monad.Trans.Resource
+ import qualified Data.IORef as I
+ import Control.Monad.Morph (MFunctor (..))
+@@ -251,11 +252,17 @@
+     liftResourceT = lift . liftResourceT
+     {-# INLINE liftResourceT #-}
+ 
++instance Monad m => Semigroup (ConduitM i o m ()) where
++    (<>) = (>>)
++    {-# INLINE (<>) #-}
++
+ instance Monad m => Monoid (ConduitM i o m ()) where
+     mempty = return ()
+     {-# INLINE mempty #-}
+-    mappend = (>>)
++#if !(MIN_VERSION_base(4,11,0))
++    mappend = (<>)
+     {-# INLINE mappend #-}
++#endif
+ 
+ instance PrimMonad m => PrimMonad (ConduitM i o m) where
+   type PrimState (ConduitM i o m) = PrimState m
+diff -ru conduit-1.2.12.1.orig/Data/Conduit/Internal/Pipe.hs conduit-1.2.12.1/Data/Conduit/Internal/Pipe.hs
+--- conduit-1.2.12.1.orig/Data/Conduit/Internal/Pipe.hs	2017-04-19 09:32:04.000000000 -0400
++++ conduit-1.2.12.1/Data/Conduit/Internal/Pipe.hs	2018-01-06 17:28:42.592793670 -0500
+@@ -59,6 +59,7 @@
+ import Control.Monad.Primitive (PrimMonad, PrimState, primitive)
+ import Data.Void (Void, absurd)
+ import Data.Monoid (Monoid (mappend, mempty))
++import Data.Semigroup (Semigroup ((<>)))
+ import Control.Monad.Trans.Resource
+ import qualified GHC.Exts
+ import Control.Monad.Morph (MFunctor (..))
+@@ -151,11 +152,17 @@
+         go (HaveOutput p c o) = HaveOutput (go p) c o
+     {-# INLINE catch #-}
+ 
++instance Monad m => Semigroup (Pipe l i o u m ()) where
++    (<>) = (>>)
++    {-# INLINE (<>) #-}
++
+ instance Monad m => Monoid (Pipe l i o u m ()) where
+     mempty = return ()
+     {-# INLINE mempty #-}
+-    mappend = (>>)
++#if !(MIN_VERSION_base(4,11,0))
++    mappend = (<>)
+     {-# INLINE mappend #-}
++#endif
+ 
+ instance PrimMonad m => PrimMonad (Pipe l i o u m) where
+   type PrimState (Pipe l i o u m) = PrimState m
+Only in conduit-1.2.12.1: .ghc.environment.x86_64-linux-8.4.0.20171222
+diff -ru conduit-1.2.12.1.orig/test/Data/Conduit/StreamSpec.hs conduit-1.2.12.1/test/Data/Conduit/StreamSpec.hs
+--- conduit-1.2.12.1.orig/test/Data/Conduit/StreamSpec.hs	2015-11-08 21:09:15.000000000 -0500
++++ conduit-1.2.12.1/test/Data/Conduit/StreamSpec.hs	2018-01-06 17:30:27.112796303 -0500
+@@ -19,6 +19,7 @@
+ import qualified Data.List
+ import qualified Data.Maybe
+ import           Data.Monoid (Monoid(..))
++import           Data.Semigroup (Semigroup(..))
+ import           Prelude
+     ((.), ($), (>>=), (=<<), return, (==), Int, id, Maybe(..), Monad,
+      Eq, Show, String, Functor, fst, snd)
+@@ -502,9 +503,14 @@
+ newtype Sum a = Sum a
+   deriving (Eq, Show, Arbitrary)
+ 
++instance Prelude.Num a => Semigroup (Sum a) where
++  Sum x <> Sum y = Sum $ x Prelude.+ y
++
+ instance Prelude.Num a => Monoid (Sum a) where
+   mempty = Sum 0
+-  mappend (Sum x) (Sum y) = Sum $ x Prelude.+ y
++#if !(MIN_VERSION_base(4,11,0))
++  mappend = (<>)
++#endif
+ 
+ preventFusion :: a -> a
+ preventFusion = id

--- a/scripts/haskell-src-exts-util-0.2.1.2.patch
+++ b/scripts/haskell-src-exts-util-0.2.1.2.patch
@@ -1,0 +1,42 @@
+diff -ru haskell-src-exts-util-0.2.1.2.orig/haskell-src-exts-util.cabal haskell-src-exts-util-0.2.1.2/haskell-src-exts-util.cabal
+--- haskell-src-exts-util-0.2.1.2.orig/haskell-src-exts-util.cabal	2018-01-06 17:14:37.088772378 -0500
++++ haskell-src-exts-util-0.2.1.2/haskell-src-exts-util.cabal	2018-01-06 17:17:23.304776564 -0500
+@@ -27,6 +27,7 @@
+     , containers
+     , data-default
+     , haskell-src-exts
++    , semigroups
+     , transformers
+     , uniplate
+   exposed-modules:
+diff -ru haskell-src-exts-util-0.2.1.2.orig/src/Language/Haskell/Exts/FreeVars.hs haskell-src-exts-util-0.2.1.2/src/Language/Haskell/Exts/FreeVars.hs
+--- haskell-src-exts-util-0.2.1.2.orig/src/Language/Haskell/Exts/FreeVars.hs	2017-08-25 15:48:57.000000000 -0400
++++ haskell-src-exts-util-0.2.1.2/src/Language/Haskell/Exts/FreeVars.hs	2018-01-06 17:18:25.852778139 -0500
+@@ -1,3 +1,4 @@
++{-# LANGUAGE CPP                 #-}
+ {-# LANGUAGE FlexibleContexts    #-}
+ {-# LANGUAGE FlexibleInstances   #-}
+ {-# LANGUAGE ScopedTypeVariables #-}
+@@ -16,6 +17,7 @@
+ import           Data.Data
+ import           Data.Generics.Uniplate.Data
+ import           Data.Monoid (Monoid(..))
++import           Data.Semigroup (Semigroup(..))
+ import           Data.Set                      (Set)
+ import qualified Data.Set                      as Set
+ import           Language.Haskell.Exts
+@@ -28,9 +30,14 @@
+ 
+ data Vars = Vars {bound :: Set (Name ()), free :: Set (Name ())}
+ 
++instance Semigroup Vars where
++    Vars x1 x2 <> Vars y1 y2 = Vars (x1 ^+ y1) (x2 ^+ y2)
++
+ instance Monoid Vars where
+     mempty = Vars Set.empty Set.empty
++#if !(MIN_VERSION_base(4,11,0))
+     mappend (Vars x1 x2) (Vars y1 y2) = Vars (x1 ^+ y1) (x2 ^+ y2)
++#endif
+     mconcat fvs = Vars (Set.unions $ map bound fvs) (Set.unions $ map free fvs)
+ 
+ class AllVars a where

--- a/scripts/streaming-0.2.0.0.patch
+++ b/scripts/streaming-0.2.0.0.patch
@@ -1,0 +1,74 @@
+diff -ru streaming-0.2.0.0.orig/src/Data/Functor/Of.hs streaming-0.2.0.0/src/Data/Functor/Of.hs
+--- streaming-0.2.0.0.orig/src/Data/Functor/Of.hs	2017-12-09 10:17:19.000000000 -0500
++++ streaming-0.2.0.0/src/Data/Functor/Of.hs	2018-01-06 17:11:05.816767057 -0500
+@@ -1,7 +1,8 @@
+ {-# LANGUAGE CPP, DeriveDataTypeable, DeriveTraversable, DeriveFoldable,
+        DeriveGeneric #-}
+ module Data.Functor.Of where
+-import Data.Monoid
++import Data.Monoid (Monoid (..))
++import Data.Semigroup (Semigroup (..))
+ import Control.Applicative
+ import Data.Traversable (Traversable)
+ import Data.Foldable (Foldable)
+@@ -19,11 +20,17 @@
+               Read, Show, Traversable, Typeable, Generic, Generic1)
+ infixr 5 :>
+ 
++instance (Semigroup a, Semigroup b) => Semigroup (Of a b) where
++  (m :> w) <> (m' :> w') = (m <> m') :> (w <> w')
++  {-#INLINE (<>) #-}
++
+ instance (Monoid a, Monoid b) => Monoid (Of a b) where
+   mempty = mempty :> mempty
+   {-#INLINE mempty #-}
++#if !(MIN_VERSION_base(4,11,0))
+   mappend (m :> w) (m' :> w') = mappend m m' :> mappend w w'
+   {-#INLINE mappend #-}
++#endif
+ 
+ instance Functor (Of a) where
+   fmap f (a :> x) = a :> f x
+diff -ru streaming-0.2.0.0.orig/src/Streaming/Internal.hs streaming-0.2.0.0/src/Streaming/Internal.hs
+--- streaming-0.2.0.0.orig/src/Streaming/Internal.hs	2017-12-09 12:35:01.000000000 -0500
++++ streaming-0.2.0.0/src/Streaming/Internal.hs	2018-01-06 17:09:49.784765142 -0500
+@@ -94,7 +94,8 @@
+ import Control.Applicative
+ import Data.Function ( on )
+ import Control.Monad.Morph
+-import Data.Monoid (Monoid (..), (<>))
++import Data.Monoid (Monoid (..))
++import Data.Semigroup (Semigroup (..))
+ import Data.Data (Typeable)
+ import Prelude hiding (splitAt)
+ import Data.Functor.Compose
+@@ -295,11 +296,17 @@
+   str <|> str' = zipsWith' liftA2 str str'
+   {-#INLINE (<|>) #-}
+ 
++instance (Functor f, Monad m, Semigroup w) => Semigroup (Stream f m w) where
++  a <> b = a >>= \w -> fmap (w <>) b
++  {-#INLINE (<>) #-}
++
+ instance (Functor f, Monad m, Monoid w) => Monoid (Stream f m w) where
+   mempty = return mempty
+   {-#INLINE mempty #-}
+-  mappend a b = a >>= \w -> fmap (w <>) b
++#if !(MIN_VERSION_base(4,11,0))
++  mappend a b = a >>= \w -> fmap (w `mappend`) b
+   {-#INLINE mappend #-}
++#endif
+ 
+ instance (Applicative f, Monad m) => MonadPlus (Stream f m) where
+   mzero = empty
+diff -ru streaming-0.2.0.0.orig/streaming.cabal streaming-0.2.0.0/streaming.cabal
+--- streaming-0.2.0.0.orig/streaming.cabal	2018-01-06 14:14:32.644500285 -0500
++++ streaming-0.2.0.0/streaming.cabal	2018-01-06 17:06:24.308759968 -0500
+@@ -217,6 +217,7 @@
+       base >=4.8 && <5
+     , mtl >=2.1 && <2.3
+     , mmorph >=1.0 && <1.2
++    , semigroups >= 0.18 && <0.19
+     , transformers >=0.5 && <0.6
+     , transformers-base < 0.5
+     , exceptions > 0.5 && < 0.9


### PR DESCRIPTION
I needed these recently when upgrading `machines` and `rcu` to GHC 8.4.1-alpha.