### PR TITLE
Add patches for bytestring-trie and critbit

### DIFF
--- a/patches/bytestring-trie-0.2.4.1.patch
+++ b/patches/bytestring-trie-0.2.4.1.patch
@@ -1,0 +1,32 @@
+diff -ru bytestring-trie-0.2.4.1.orig/src/Data/Trie/Internal.hs bytestring-trie-0.2.4.1/src/Data/Trie/Internal.hs
+--- bytestring-trie-0.2.4.1.orig/src/Data/Trie/Internal.hs	2015-04-04 20:59:21.000000000 -0400
++++ bytestring-trie-0.2.4.1/src/Data/Trie/Internal.hs	2018-01-07 18:38:48.327075433 -0500
+@@ -69,6 +69,9 @@
+ import Data.Binary
+ 
+ import Data.Monoid         (Monoid(..))
++#if MIN_VERSION_base(4,9,0)
++import Data.Semigroup      (Semigroup(..))
++#endif
+ import Control.Monad       (liftM, liftM3, liftM4)
+ #ifdef APPLICATIVE_IN_BASE
+ import Control.Monad       (ap)
+@@ -302,10 +305,18 @@
+                                unionL = mergeBy (\x _ -> Just x)
+ 
+ 
++#if MIN_VERSION_base(4,9,0)
++instance (Semigroup a) => Semigroup (Trie a) where
++    (<>) = mergeBy $ \x y -> Just (x <> y)
++#endif
++
++
+ -- This instance is more sensible than Data.IntMap and Data.Map's
+ instance (Monoid a) => Monoid (Trie a) where
+     mempty  = empty
++#if !(MIN_VERSION_base(4,11,0))
+     mappend = mergeBy $ \x y -> Just (x `mappend` y)
++#endif
+ 
+ 
+ -- Since the Monoid instance isn't natural in @a@, I can't think

--- a/patches/critbit-0.2.0.0.patch
+++ b/patches/critbit-0.2.0.0.patch
@@ -1,0 +1,97 @@
+diff -ru critbit-0.2.0.0.orig/Data/CritBit/Set.hs critbit-0.2.0.0/Data/CritBit/Set.hs
+--- critbit-0.2.0.0.orig/Data/CritBit/Set.hs	2014-07-04 01:40:10.000000000 -0400
++++ critbit-0.2.0.0/Data/CritBit/Set.hs	2018-01-07 18:44:32.747084107 -0500
+@@ -1,3 +1,4 @@
++{-# LANGUAGE CPP #-}
+ {-# OPTIONS_GHC -fno-warn-orphans #-}
+ 
+ -- |
+@@ -90,6 +91,9 @@
+ import Data.Foldable (Foldable, foldMap)
+ import Data.Maybe (isJust)
+ import Data.Monoid (Monoid(..))
++#if MIN_VERSION_base(4,9,0)
++import Data.Semigroup (Semigroup(..))
++#endif
+ import Prelude hiding (null, filter, map, foldl, foldr)
+ import qualified Data.CritBit.Tree as T
+ import qualified Data.List as List
+@@ -97,9 +101,16 @@
+ instance (Show a) => Show (Set a) where
+     show s = "fromList " ++ show (toList s)
+ 
++#if MIN_VERSION_base(4,9,0)
++instance CritBitKey k => Semigroup (Set k) where
++    (<>) = union
++#endif
++
+ instance CritBitKey k => Monoid (Set k) where
+     mempty  = empty
++#if !(MIN_VERSION_base(4,11,0))
+     mappend = union
++#endif
+     mconcat = unions
+ 
+ instance Foldable Set where
+diff -ru critbit-0.2.0.0.orig/Data/CritBit/Tree.hs critbit-0.2.0.0/Data/CritBit/Tree.hs
+--- critbit-0.2.0.0.orig/Data/CritBit/Tree.hs	2014-07-04 01:40:10.000000000 -0400
++++ critbit-0.2.0.0/Data/CritBit/Tree.hs	2018-01-07 18:43:26.219082431 -0500
+@@ -1,4 +1,4 @@
+-{-# LANGUAGE BangPatterns, RecordWildCards, ScopedTypeVariables #-}
++{-# LANGUAGE CPP, BangPatterns, RecordWildCards, ScopedTypeVariables #-}
+ {-# OPTIONS_GHC -fno-warn-orphans #-}
+ 
+ -- |
+@@ -153,21 +153,31 @@
+ import Data.CritBit.Types.Internal
+ import Data.Maybe (fromMaybe)
+ import Data.Monoid (Monoid(..))
++#if MIN_VERSION_base(4,9,0)
++import Data.Semigroup (Semigroup(..))
++#endif
+ import Data.Traversable (Traversable(traverse))
+ import Prelude hiding (foldl, foldr, lookup, null, map, filter)
+ import qualified Data.Array as A
+ import qualified Data.Foldable as Foldable
+ import qualified Data.List as List
+ 
++#if MIN_VERSION_base(4,9,0)
++instance CritBitKey k => Semigroup (CritBit k v) where
++    (<>) = union
++#endif
++
+ instance CritBitKey k => Monoid (CritBit k v) where
+     mempty  = empty
++#if !(MIN_VERSION_base(4,11,0))
+     mappend = union
++#endif
+     mconcat = unions
+ 
+ instance CritBitKey k => Traversable (CritBit k) where
+     traverse f m = traverseWithKey (\_ v -> f v) m
+ 
+-infixl 9 !, \\
++infixl 9 !, \\ -- Comment needed here to avoid CPP bug
+ 
+ -- | /O(k)/. Find the value at a key.
+ -- Calls 'error' when the element can not be found.
+@@ -1248,8 +1258,7 @@
+ -- > deleteFindMin     Error: can not return the minimal element of an empty map
+ deleteFindMin :: CritBit k v -> ((k, v), CritBit k v)
+ deleteFindMin = fromMaybe (error msg) . minViewWithKey
+-  where msg = "CritBit.deleteFindMin: cannot return the minimal \
+-              \element of an empty map"
++  where msg = "CritBit.deleteFindMin: cannot return the minimal element of an empty map"
+ {-# INLINABLE deleteFindMin #-}
+ 
+ -- | /O(k)/. Delete and find the maximal element.
+@@ -1258,8 +1267,7 @@
+ -- > deleteFindMax     Error: can not return the maximal element of an empty map
+ deleteFindMax :: CritBit k v -> ((k, v), CritBit k v)
+ deleteFindMax = fromMaybe (error msg) . maxViewWithKey
+-  where msg = "CritBit.deleteFindMax: cannot return the minimal \
+-              \element of an empty map"
++  where msg = "CritBit.deleteFindMax: cannot return the minimal element of an empty map"
+ {-# INLINABLE deleteFindMax #-}
+ 
+ -- | /O(k')/. Retrieves the value associated with minimal key of the


### PR DESCRIPTION
I needed these for the examples in `criterion`.