### PR TITLE
Add a patch for vinyl-0.7.0

### DIFF
--- a/patches/vinyl-0.7.0.patch
+++ b/patches/vinyl-0.7.0.patch
@@ -1,0 +1,37 @@
+diff --git a/Data/Vinyl/Core.hs b/Data/Vinyl/Core.hs
+index 4400785..5d31570 100644
+--- a/Data/Vinyl/Core.hs
++++ b/Data/Vinyl/Core.hs
+@@ -15,7 +15,8 @@
+ 
+ module Data.Vinyl.Core where
+ 
+-import Data.Monoid
++import Data.Monoid hiding ((<>))
++import Data.Semigroup
+ import Foreign.Ptr (castPtr, plusPtr)
+ import Foreign.Storable (Storable(..))
+ import Data.Vinyl.Functor
+@@ -226,13 +227,19 @@ instance RecAll f rs Show => Show (Rec f rs) where
+       . rmap (\(Compose (Dict x)) -> Const $ show x)
+       $ reifyConstraint (Proxy :: Proxy Show) xs
+ 
++instance Semigroup (Rec f '[]) where
++  RNil <> RNil = RNil
++
++instance (Semigroup (f r), Semigroup (Rec f rs)) => Semigroup (Rec f (r ': rs)) where
++  (x :& xs) <> (y :& ys) = (x <> y) :& (xs <> ys)
++
+ instance Monoid (Rec f '[]) where
+   mempty = RNil
+-  RNil `mappend` RNil = RNil
++  mappend = (<>)
+ 
+-instance (Monoid (f r), Monoid (Rec f rs)) => Monoid (Rec f (r ': rs)) where
++instance (Semigroup (f r), Semigroup (Rec f rs), Monoid (f r), Monoid (Rec f rs)) => Monoid (Rec f (r ': rs)) where
+   mempty = mempty :& mempty
+-  (x :& xs) `mappend` (y :& ys) = (x <> y) :& (xs <> ys)
++  mappend = (<>)
+ 
+ instance Eq (Rec f '[]) where
+   _ == _ = True


### PR DESCRIPTION
It seems it's been affected by Semigroup superclass migration
Presumably this could just be an upstream patch