### PR TITLE
Fix nix scripts

### DIFF
--- a/scripts/generate-nix-overrides.hs
+++ b/scripts/generate-nix-overrides.hs
@@ -26,7 +26,7 @@ generateOverrides prefix patchDir = do
 mkOverride :: (PackageName, [([Int], String)]) -> String
 mkOverride (display -> pName, patches) =
   unlines $
-    [unwords [pName, "= if false then", superPname]]
+    [unwords [pName, "= if", superPname, "== null then", superPname]]
      ++ packages ++
     [ "else", superPname, ";"]
   where

--- a/scripts/overrides.nix
+++ b/scripts/overrides.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     cp patches.nix $out
-    ensureDir $script/patches
+    mkdir -p $script/patches
     cp -r patches $script/patches
   '';
 


### PR DESCRIPTION
* Don't try to apply patches to built in, fixed packages which come with the compiler
* Remove use of deprecated `ensureDir`. 