### PR TITLE
Two packages broken under template-haskell-2.14

### DIFF
--- a/patches/singletons-2.4.1.patch
+++ b/patches/singletons-2.4.1.patch
@@ -1,0 +1,58 @@
+commit 470dcb77200a60701907ad958af04e5b9e18d7a3
+Author: Ryan Scott <ryan.gl.scott@gmail.com>
+Date:   Tue Apr 3 14:45:48 2018 -0400
+
+    Allow building with template-haskell-2.14
+
+diff --git a/src/Data/Singletons/Single/Monad.hs b/src/Data/Singletons/Single/Monad.hs
+index 7da2a7b..b1928b2 100644
+--- a/src/Data/Singletons/Single/Monad.hs
++++ b/src/Data/Singletons/Single/Monad.hs
+@@ -8,7 +8,7 @@ This file defines the SgM monad and its operations, for use during singling.
+ The SgM monad allows reading from a SgEnv environment and is wrapped around a Q.
+ -}
+ 
+-{-# LANGUAGE GeneralizedNewtypeDeriving, ParallelListComp, TemplateHaskell #-}
++{-# LANGUAGE GeneralizedNewtypeDeriving, ParallelListComp, TemplateHaskell, CPP #-}
+ 
+ module Data.Singletons.Single.Monad (
+   SgM, bindLets, lookupVarE, lookupConE,
+@@ -72,7 +72,12 @@ instance Quasi SgM where
+   qReifyConStrictness = liftSgM `comp1` qReifyConStrictness
+   qIsExtEnabled       = liftSgM `comp1` qIsExtEnabled
+   qExtsEnabled        = liftSgM qExtsEnabled
++#if MIN_VERSION_template_haskell(2,14,0)
++  qAddForeignFilePath = liftSgM `comp2` qAddForeignFilePath
++  qAddTempFile        = liftSgM `comp1` qAddTempFile
++#else
+   qAddForeignFile     = liftSgM `comp2` qAddForeignFile
++#endif
+   qAddCorePlugin      = liftSgM `comp1` qAddCorePlugin
+ 
+   qRecover (SgM handler) (SgM body) = do
+diff --git a/src/Data/Singletons/Util.hs b/src/Data/Singletons/Util.hs
+index f11bc7e..1a30765 100644
+--- a/src/Data/Singletons/Util.hs
++++ b/src/Data/Singletons/Util.hs
+@@ -11,7 +11,7 @@ Users of the package should not need to consult this file.
+              TemplateHaskell, GeneralizedNewtypeDeriving,
+              MultiParamTypeClasses, StandaloneDeriving,
+              UndecidableInstances, MagicHash, UnboxedTuples,
+-             LambdaCase, NoMonomorphismRestriction #-}
++             LambdaCase, NoMonomorphismRestriction, CPP #-}
+ 
+ module Data.Singletons.Util where
+ 
+@@ -404,7 +404,12 @@ instance (Quasi q, Monoid m) => Quasi (QWithAux m q) where
+   qReifyConStrictness = lift `comp1` qReifyConStrictness
+   qIsExtEnabled       = lift `comp1` qIsExtEnabled
+   qExtsEnabled        = lift qExtsEnabled
++#if MIN_VERSION_template_haskell(2,14,0)
++  qAddForeignFilePath = lift `comp2` qAddForeignFilePath
++  qAddTempFile        = lift `comp1` qAddTempFile
++#else
+   qAddForeignFile     = lift `comp2` qAddForeignFile
++#endif
+   qAddCorePlugin      = lift `comp1` qAddCorePlugin
+ 
+   qRecover exp handler = do

--- a/patches/th-orphans-0.13.5.patch
+++ b/patches/th-orphans-0.13.5.patch
@@ -1,0 +1,266 @@
+commit 3fa80a7a4c7e2af4d1ddaeab367068a6456028f9
+Author: Ryan Scott <ryan.gl.scott@gmail.com>
+Date:   Tue Apr 3 14:44:43 2018 -0400
+
+    Fix the build with template-haskell-2.14
+
+diff --git a/src/Language/Haskell/TH/Instances.hs b/src/Language/Haskell/TH/Instances.hs
+index ca0796c..bd4d85b 100644
+--- a/src/Language/Haskell/TH/Instances.hs
++++ b/src/Language/Haskell/TH/Instances.hs
+@@ -356,147 +356,159 @@ instance Applicative PprM where
+ #endif
+ 
+ instance Quasi m => Quasi (ReaderT r m) where
+-  qNewName            = MTL.lift . qNewName
+-  qReport a b         = MTL.lift $ qReport a b
+-  qRecover m1 m2      = ReaderT $ \ r -> runReaderT m1 r `qRecover` runReaderT m2 r
+-  qReify              = MTL.lift . qReify
+-  qLocation           = MTL.lift qLocation
+-  qRunIO              = MTL.lift . qRunIO
++  qNewName                = MTL.lift . qNewName
++  qReport a b             = MTL.lift $ qReport a b
++  qRecover m1 m2          = ReaderT $ \ r -> runReaderT m1 r `qRecover` runReaderT m2 r
++  qReify                  = MTL.lift . qReify
++  qLocation               = MTL.lift qLocation
++  qRunIO                  = MTL.lift . qRunIO
+ #if MIN_VERSION_template_haskell(2,7,0)
+-  qReifyInstances a b = MTL.lift $ qReifyInstances a b
+-  qLookupName a b     = MTL.lift $ qLookupName a b
+-  qAddDependentFile   = MTL.lift . qAddDependentFile
++  qReifyInstances a b     = MTL.lift $ qReifyInstances a b
++  qLookupName a b         = MTL.lift $ qLookupName a b
++  qAddDependentFile       = MTL.lift . qAddDependentFile
+ # if MIN_VERSION_template_haskell(2,9,0)
+-  qReifyRoles         = MTL.lift . qReifyRoles
+-  qReifyAnnotations   = MTL.lift . qReifyAnnotations
+-  qReifyModule        = MTL.lift . qReifyModule
+-  qAddTopDecls        = MTL.lift . qAddTopDecls
+-  qAddModFinalizer    = MTL.lift . qAddModFinalizer
+-  qGetQ               = MTL.lift qGetQ
+-  qPutQ               = MTL.lift . qPutQ
++  qReifyRoles             = MTL.lift . qReifyRoles
++  qReifyAnnotations       = MTL.lift . qReifyAnnotations
++  qReifyModule            = MTL.lift . qReifyModule
++  qAddTopDecls            = MTL.lift . qAddTopDecls
++  qAddModFinalizer        = MTL.lift . qAddModFinalizer
++  qGetQ                   = MTL.lift qGetQ
++  qPutQ                   = MTL.lift . qPutQ
+ # endif
+ # if MIN_VERSION_template_haskell(2,11,0)
+-  qReifyFixity        = MTL.lift . qReifyFixity
+-  qReifyConStrictness = MTL.lift . qReifyConStrictness
+-  qIsExtEnabled       = MTL.lift . qIsExtEnabled
+-  qExtsEnabled        = MTL.lift qExtsEnabled
++  qReifyFixity            = MTL.lift . qReifyFixity
++  qReifyConStrictness     = MTL.lift . qReifyConStrictness
++  qIsExtEnabled           = MTL.lift . qIsExtEnabled
++  qExtsEnabled            = MTL.lift qExtsEnabled
+ # endif
+ #elif MIN_VERSION_template_haskell(2,5,0)
+-  qClassInstances a b = MTL.lift $ qClassInstances a b
++  qClassInstances a b     = MTL.lift $ qClassInstances a b
+ #endif
+-#if MIN_VERSION_template_haskell(2,12,0)
+-  qAddForeignFile a b = MTL.lift $ qAddForeignFile a b
++#if MIN_VERSION_template_haskell(2,14,0)
++  qAddForeignFilePath a b = MTL.lift $ qAddForeignFilePath a b
++  qAddTempFile            = MTL.lift . qAddTempFile
++#elif MIN_VERSION_template_haskell(2,12,0)
++  qAddForeignFile a b     = MTL.lift $ qAddForeignFile a b
+ #endif
+ #if MIN_VERSION_template_haskell(2,13,0)
+-  qAddCorePlugin      = MTL.lift . qAddCorePlugin
++  qAddCorePlugin          = MTL.lift . qAddCorePlugin
+ #endif
+ 
+ instance (Quasi m, Monoid w) => Quasi (WriterT w m) where
+-  qNewName            = MTL.lift . qNewName
+-  qReport a b         = MTL.lift $ qReport a b
+-  qRecover m1 m2      = WriterT $ runWriterT m1 `qRecover` runWriterT m2
+-  qReify              = MTL.lift . qReify
+-  qLocation           = MTL.lift qLocation
+-  qRunIO              = MTL.lift . qRunIO
++  qNewName                = MTL.lift . qNewName
++  qReport a b             = MTL.lift $ qReport a b
++  qRecover m1 m2          = WriterT $ runWriterT m1 `qRecover` runWriterT m2
++  qReify                  = MTL.lift . qReify
++  qLocation               = MTL.lift qLocation
++  qRunIO                  = MTL.lift . qRunIO
+ #if MIN_VERSION_template_haskell(2,7,0)
+-  qReifyInstances a b = MTL.lift $ qReifyInstances a b
+-  qLookupName a b     = MTL.lift $ qLookupName a b
+-  qAddDependentFile   = MTL.lift . qAddDependentFile
++  qReifyInstances a b     = MTL.lift $ qReifyInstances a b
++  qLookupName a b         = MTL.lift $ qLookupName a b
++  qAddDependentFile       = MTL.lift . qAddDependentFile
+ # if MIN_VERSION_template_haskell(2,9,0)
+-  qReifyRoles         = MTL.lift . qReifyRoles
+-  qReifyAnnotations   = MTL.lift . qReifyAnnotations
+-  qReifyModule        = MTL.lift . qReifyModule
+-  qAddTopDecls        = MTL.lift . qAddTopDecls
+-  qAddModFinalizer    = MTL.lift . qAddModFinalizer
+-  qGetQ               = MTL.lift qGetQ
+-  qPutQ               = MTL.lift . qPutQ
++  qReifyRoles             = MTL.lift . qReifyRoles
++  qReifyAnnotations       = MTL.lift . qReifyAnnotations
++  qReifyModule            = MTL.lift . qReifyModule
++  qAddTopDecls            = MTL.lift . qAddTopDecls
++  qAddModFinalizer        = MTL.lift . qAddModFinalizer
++  qGetQ                   = MTL.lift qGetQ
++  qPutQ                   = MTL.lift . qPutQ
+ # endif
+ # if MIN_VERSION_template_haskell(2,11,0)
+-  qReifyFixity        = MTL.lift . qReifyFixity
+-  qReifyConStrictness = MTL.lift . qReifyConStrictness
+-  qIsExtEnabled       = MTL.lift . qIsExtEnabled
+-  qExtsEnabled        = MTL.lift qExtsEnabled
++  qReifyFixity            = MTL.lift . qReifyFixity
++  qReifyConStrictness     = MTL.lift . qReifyConStrictness
++  qIsExtEnabled           = MTL.lift . qIsExtEnabled
++  qExtsEnabled            = MTL.lift qExtsEnabled
+ # endif
+ #elif MIN_VERSION_template_haskell(2,5,0)
+-  qClassInstances a b = MTL.lift $ qClassInstances a b
++  qClassInstances a b     = MTL.lift $ qClassInstances a b
+ #endif
+-#if MIN_VERSION_template_haskell(2,12,0)
+-  qAddForeignFile a b = MTL.lift $ qAddForeignFile a b
++#if MIN_VERSION_template_haskell(2,14,0)
++  qAddForeignFilePath a b = MTL.lift $ qAddForeignFilePath a b
++  qAddTempFile            = MTL.lift . qAddTempFile
++#elif MIN_VERSION_template_haskell(2,12,0)
++  qAddForeignFile a b     = MTL.lift $ qAddForeignFile a b
+ #endif
+ #if MIN_VERSION_template_haskell(2,13,0)
+-  qAddCorePlugin      = MTL.lift . qAddCorePlugin
++  qAddCorePlugin          = MTL.lift . qAddCorePlugin
+ #endif
+ 
+ instance Quasi m => Quasi (StateT s m) where
+-  qNewName            = MTL.lift . qNewName
+-  qReport a b         = MTL.lift $ qReport a b
+-  qRecover m1 m2      = StateT $ \ s -> runStateT m1 s `qRecover` runStateT m2 s
+-  qReify              = MTL.lift . qReify
+-  qLocation           = MTL.lift qLocation
+-  qRunIO              = MTL.lift . qRunIO
++  qNewName                = MTL.lift . qNewName
++  qReport a b             = MTL.lift $ qReport a b
++  qRecover m1 m2          = StateT $ \ s -> runStateT m1 s `qRecover` runStateT m2 s
++  qReify                  = MTL.lift . qReify
++  qLocation               = MTL.lift qLocation
++  qRunIO                  = MTL.lift . qRunIO
+ #if MIN_VERSION_template_haskell(2,7,0)
+-  qReifyInstances a b = MTL.lift $ qReifyInstances a b
+-  qLookupName a b     = MTL.lift $ qLookupName a b
+-  qAddDependentFile   = MTL.lift . qAddDependentFile
++  qReifyInstances a b     = MTL.lift $ qReifyInstances a b
++  qLookupName a b         = MTL.lift $ qLookupName a b
++  qAddDependentFile       = MTL.lift . qAddDependentFile
+ # if MIN_VERSION_template_haskell(2,9,0)
+-  qReifyRoles         = MTL.lift . qReifyRoles
+-  qReifyAnnotations   = MTL.lift . qReifyAnnotations
+-  qReifyModule        = MTL.lift . qReifyModule
+-  qAddTopDecls        = MTL.lift . qAddTopDecls
+-  qAddModFinalizer    = MTL.lift . qAddModFinalizer
+-  qGetQ               = MTL.lift qGetQ
+-  qPutQ               = MTL.lift . qPutQ
++  qReifyRoles             = MTL.lift . qReifyRoles
++  qReifyAnnotations       = MTL.lift . qReifyAnnotations
++  qReifyModule            = MTL.lift . qReifyModule
++  qAddTopDecls            = MTL.lift . qAddTopDecls
++  qAddModFinalizer        = MTL.lift . qAddModFinalizer
++  qGetQ                   = MTL.lift qGetQ
++  qPutQ                   = MTL.lift . qPutQ
+ # endif
+ # if MIN_VERSION_template_haskell(2,11,0)
+-  qReifyFixity        = MTL.lift . qReifyFixity
+-  qReifyConStrictness = MTL.lift . qReifyConStrictness
+-  qIsExtEnabled       = MTL.lift . qIsExtEnabled
+-  qExtsEnabled        = MTL.lift qExtsEnabled
++  qReifyFixity            = MTL.lift . qReifyFixity
++  qReifyConStrictness     = MTL.lift . qReifyConStrictness
++  qIsExtEnabled           = MTL.lift . qIsExtEnabled
++  qExtsEnabled            = MTL.lift qExtsEnabled
+ # endif
+ #elif MIN_VERSION_template_haskell(2,5,0)
+-  qClassInstances a b = MTL.lift $ qClassInstances a b
++  qClassInstances a b     = MTL.lift $ qClassInstances a b
+ #endif
+-#if MIN_VERSION_template_haskell(2,12,0)
+-  qAddForeignFile a b = MTL.lift $ qAddForeignFile a b
++#if MIN_VERSION_template_haskell(2,14,0)
++  qAddForeignFilePath a b = MTL.lift $ qAddForeignFilePath a b
++  qAddTempFile            = MTL.lift . qAddTempFile
++#elif MIN_VERSION_template_haskell(2,12,0)
++  qAddForeignFile a b     = MTL.lift $ qAddForeignFile a b
+ #endif
+ #if MIN_VERSION_template_haskell(2,13,0)
+-  qAddCorePlugin      = MTL.lift . qAddCorePlugin
++  qAddCorePlugin          = MTL.lift . qAddCorePlugin
+ #endif
+ 
+ instance (Quasi m, Monoid w) => Quasi (RWST r w s m) where
+-  qNewName            = MTL.lift . qNewName
+-  qReport a b         = MTL.lift $ qReport a b
+-  qRecover m1 m2      = RWST $ \ r s -> runRWST m1 r s `qRecover` runRWST m2 r s
+-  qReify              = MTL.lift . qReify
+-  qLocation           = MTL.lift qLocation
+-  qRunIO              = MTL.lift . qRunIO
++  qNewName                = MTL.lift . qNewName
++  qReport a b             = MTL.lift $ qReport a b
++  qRecover m1 m2          = RWST $ \ r s -> runRWST m1 r s `qRecover` runRWST m2 r s
++  qReify                  = MTL.lift . qReify
++  qLocation               = MTL.lift qLocation
++  qRunIO                  = MTL.lift . qRunIO
+ #if MIN_VERSION_template_haskell(2,7,0)
+-  qReifyInstances a b = MTL.lift $ qReifyInstances a b
+-  qLookupName a b     = MTL.lift $ qLookupName a b
+-  qAddDependentFile   = MTL.lift . qAddDependentFile
++  qReifyInstances a b     = MTL.lift $ qReifyInstances a b
++  qLookupName a b         = MTL.lift $ qLookupName a b
++  qAddDependentFile       = MTL.lift . qAddDependentFile
+ # if MIN_VERSION_template_haskell(2,9,0)
+-  qReifyRoles         = MTL.lift . qReifyRoles
+-  qReifyAnnotations   = MTL.lift . qReifyAnnotations
+-  qReifyModule        = MTL.lift . qReifyModule
+-  qAddTopDecls        = MTL.lift . qAddTopDecls
+-  qAddModFinalizer    = MTL.lift . qAddModFinalizer
+-  qGetQ               = MTL.lift qGetQ
+-  qPutQ               = MTL.lift . qPutQ
++  qReifyRoles             = MTL.lift . qReifyRoles
++  qReifyAnnotations       = MTL.lift . qReifyAnnotations
++  qReifyModule            = MTL.lift . qReifyModule
++  qAddTopDecls            = MTL.lift . qAddTopDecls
++  qAddModFinalizer        = MTL.lift . qAddModFinalizer
++  qGetQ                   = MTL.lift qGetQ
++  qPutQ                   = MTL.lift . qPutQ
+ # endif
+ # if MIN_VERSION_template_haskell(2,11,0)
+-  qReifyFixity        = MTL.lift . qReifyFixity
+-  qReifyConStrictness = MTL.lift . qReifyConStrictness
+-  qIsExtEnabled       = MTL.lift . qIsExtEnabled
+-  qExtsEnabled        = MTL.lift qExtsEnabled
++  qReifyFixity            = MTL.lift . qReifyFixity
++  qReifyConStrictness     = MTL.lift . qReifyConStrictness
++  qIsExtEnabled           = MTL.lift . qIsExtEnabled
++  qExtsEnabled            = MTL.lift qExtsEnabled
+ # endif
+ #elif MIN_VERSION_template_haskell(2,5,0)
+-  qClassInstances a b = MTL.lift $ qClassInstances a b
++  qClassInstances a b     = MTL.lift $ qClassInstances a b
+ #endif
+-#if MIN_VERSION_template_haskell(2,12,0)
+-  qAddForeignFile a b = MTL.lift $ qAddForeignFile a b
++#if MIN_VERSION_template_haskell(2,14,0)
++  qAddForeignFilePath a b = MTL.lift $ qAddForeignFilePath a b
++  qAddTempFile            = MTL.lift . qAddTempFile
++#elif MIN_VERSION_template_haskell(2,12,0)
++  qAddForeignFile a b     = MTL.lift $ qAddForeignFile a b
+ #endif
+ #if MIN_VERSION_template_haskell(2,13,0)
+-  qAddCorePlugin      = MTL.lift . qAddCorePlugin
++  qAddCorePlugin          = MTL.lift . qAddCorePlugin
+ #endif
+ 
+ #if MIN_VERSION_base(4,7,0) && defined(LANGUAGE_DeriveDataTypeable) && __GLASGOW_HASKELL__ < 710


### PR DESCRIPTION
This allows `th-orphans-0.13.5` and `singletons-2.4.1` to build under `template-haskell-2.14`.