### PR TITLE
Patch bytestring-mmap, shake to work with unix-2.8

### DIFF
--- a/patches/bytestring-mmap-0.2.2.patch
+++ b/patches/bytestring-mmap-0.2.2.patch
@@ -1,0 +1,38 @@
+diff -ru bytestring-mmap-0.2.2.orig/System/IO/Posix/MMap/Lazy.hs bytestring-mmap-0.2.2/System/IO/Posix/MMap/Lazy.hs
+--- bytestring-mmap-0.2.2.orig/System/IO/Posix/MMap/Lazy.hs	2011-04-29 15:58:05.000000000 -0400
++++ bytestring-mmap-0.2.2/System/IO/Posix/MMap/Lazy.hs	2018-05-20 14:44:47.123915525 -0400
+@@ -91,7 +91,11 @@
+ --
+ unsafeMMapFile :: FilePath -> IO ByteString
+ unsafeMMapFile path = do
+-    fd   <- openFd path ReadOnly Nothing defaultFileFlags
++    fd   <- openFd path ReadOnly
++#if !(MIN_VERSION_unix(2,8,0))
++                   Nothing
++#endif
++                   defaultFileFlags
+     always (closeFd fd) $ do
+         stat <- getFdStatus fd
+         let size = fromIntegral (fileSize stat)
+diff -ru bytestring-mmap-0.2.2.orig/System/IO/Posix/MMap.hs bytestring-mmap-0.2.2/System/IO/Posix/MMap.hs
+--- bytestring-mmap-0.2.2.orig/System/IO/Posix/MMap.hs	2011-04-29 15:58:05.000000000 -0400
++++ bytestring-mmap-0.2.2/System/IO/Posix/MMap.hs	2018-05-20 14:44:17.671914783 -0400
+@@ -1,4 +1,4 @@
+-{-# LANGUAGE ForeignFunctionInterface #-}
++{-# LANGUAGE CPP, ForeignFunctionInterface #-}
+ --------------------------------------------------------------------
+ -- |
+ -- Module    :  System.IO.Posix.MMap
+@@ -98,7 +98,11 @@
+ --
+ unsafeMMapFile :: FilePath -> IO ByteString
+ unsafeMMapFile f = do
+-    fd   <- openFd f ReadOnly Nothing defaultFileFlags
++    fd   <- openFd f ReadOnly
++#if !(MIN_VERSION_unix(2,8,0))
++                   Nothing
++#endif
++                   defaultFileFlags
+     always (closeFd fd) $ do
+         stat <- getFdStatus fd
+         let size = fromIntegral (fileSize stat)

--- a/patches/shake-0.16.4.patch
+++ b/patches/shake-0.16.4.patch
@@ -1,0 +1,23 @@
+diff -ru shake-0.16.4.orig/src/General/FileLock.hs shake-0.16.4/src/General/FileLock.hs
+--- shake-0.16.4.orig/src/General/FileLock.hs	2018-04-04 15:25:53.000000000 -0400
++++ shake-0.16.4/src/General/FileLock.hs	2018-05-20 14:33:58.011899178 -0400
+@@ -60,7 +60,7 @@
+     createDirectoryRecursive $ takeDirectory file
+     tryIO $ writeFile file ""
+ 
+-    bracket (openFd file ReadWrite Nothing defaultFileFlags) closeFd $ \fd -> do
++    bracket (openSimpleFd file ReadWrite) closeFd $ \fd -> do
+         let lock = (WriteLock, AbsoluteSeek, 0, 0)
+         res <- tryIO $ setLock fd lock
+         case res of
+@@ -73,4 +73,10 @@
+                                Just (pid, _) -> "Shake process ID " ++ show pid ++ " is using this lock.\n") ++
+                           show e
+ 
++#if MIN_VERSION_unix(2,8,0)
++openSimpleFd file mode = openFd file mode defaultFileFlags
++#else
++openSimpleFd file mode = openFd file mode Nothing defaultFileFlags
++#endif
++
+ #endif


### PR DESCRIPTION
The `shake` patch is adapted from [this commit](https://github.com/ndmitchell/shake/commit/873f0746b4dcc2d5294b3181d986f658b98ec59a#diff-60a311e0dc79ef3464236696fc2df01b).