### PR TITLE
Allow tasty to build with base-4.12

### DIFF
--- a/patches/tasty-1.1.0.1.patch
+++ b/patches/tasty-1.1.0.1.patch
@@ -1,0 +1,36 @@
+diff -ru tasty-1.1.0.1.orig/Test/Tasty/CmdLine.hs tasty-1.1.0.1/Test/Tasty/CmdLine.hs
+--- tasty-1.1.0.1.orig/Test/Tasty/CmdLine.hs	2018-02-12 13:46:24.000000000 -0500
++++ tasty-1.1.0.1/Test/Tasty/CmdLine.hs	2018-06-05 07:52:59.307984985 -0400
+@@ -8,7 +8,7 @@
+   ) where
+ 
+ import Options.Applicative
+-import Data.Monoid
++import Data.Monoid (Monoid(..), (<>))
+ import Data.Proxy
+ import Data.Foldable (foldMap)
+ import Prelude  -- Silence AMP and FTP import warnings
+diff -ru tasty-1.1.0.1.orig/Test/Tasty/Ingredients/ConsoleReporter.hs tasty-1.1.0.1/Test/Tasty/Ingredients/ConsoleReporter.hs
+--- tasty-1.1.0.1.orig/Test/Tasty/Ingredients/ConsoleReporter.hs	2018-05-06 09:34:29.000000000 -0400
++++ tasty-1.1.0.1/Test/Tasty/Ingredients/ConsoleReporter.hs	2018-06-05 07:52:07.023983669 -0400
+@@ -38,7 +38,7 @@
+ import qualified Data.IntMap as IntMap
+ import Data.Char
+ import Data.Maybe
+-import Data.Monoid
++import Data.Monoid (Monoid(..), Any(..))
+ import Data.Typeable
+ import Options.Applicative hiding (str)
+ import System.IO
+diff -ru tasty-1.1.0.1.orig/Test/Tasty/Runners/Reducers.hs tasty-1.1.0.1/Test/Tasty/Runners/Reducers.hs
+--- tasty-1.1.0.1.orig/Test/Tasty/Runners/Reducers.hs	2018-05-06 09:28:51.000000000 -0400
++++ tasty-1.1.0.1/Test/Tasty/Runners/Reducers.hs	2018-06-05 07:52:07.023983669 -0400
+@@ -41,7 +41,7 @@
+ 
+ module Test.Tasty.Runners.Reducers where
+ 
+-import Data.Monoid
++import Data.Monoid (Monoid(..))
+ import Control.Applicative
+ import Prelude  -- Silence AMP import warnings
+ #if MIN_VERSION_base(4,9,0)


### PR DESCRIPTION
In http://git.haskell.org/ghc.git/commit/b67e8a3f107f7e7b2cefb526a5f956a4a3abc852, `Data.Monoid` gained the `Ap` newtype, which conflicts with a similarly named type in `tasty`. This patch adds the necessary CPP to work around the issue.