### PR TITLE
Several GHC 8.5-related patches

### DIFF
--- a/patches/adjunctions-4.4.patch
+++ b/patches/adjunctions-4.4.patch
@@ -1,0 +1,28 @@
+diff -ru adjunctions-4.4.orig/src/Data/Functor/Contravariant/Rep.hs adjunctions-4.4/src/Data/Functor/Contravariant/Rep.hs
+--- adjunctions-4.4.orig/src/Data/Functor/Contravariant/Rep.hs	2018-01-28 09:49:01.000000000 -0500
++++ adjunctions-4.4/src/Data/Functor/Contravariant/Rep.hs	2018-06-17 15:47:29.634812139 -0400
+@@ -1,7 +1,11 @@
++{-# LANGUAGE CPP #-}
+ {-# LANGUAGE FlexibleContexts #-}
+ {-# LANGUAGE FlexibleInstances #-}
+ {-# LANGUAGE TypeFamilies #-}
+ {-# LANGUAGE TypeOperators #-}
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE StarIsType #-}
++#endif
+ {-# OPTIONS_GHC -fenable-rewrite-rules #-}
+ ----------------------------------------------------------------------
+ -- |
+diff -ru adjunctions-4.4.orig/src/Data/Functor/Rep.hs adjunctions-4.4/src/Data/Functor/Rep.hs
+--- adjunctions-4.4.orig/src/Data/Functor/Rep.hs	2018-01-28 09:49:01.000000000 -0500
++++ adjunctions-4.4/src/Data/Functor/Rep.hs	2018-06-17 15:47:46.526812565 -0400
+@@ -11,6 +11,9 @@
+ {-# LANGUAGE DefaultSignatures #-}
+ {-# LANGUAGE Trustworthy #-}
+ {-# LANGUAGE TypeOperators #-}
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE StarIsType #-}
++#endif
+ {-# OPTIONS_GHC -fenable-rewrite-rules #-}
+ ----------------------------------------------------------------------
+ -- |

--- a/patches/aeson-1.4.0.0.patch
+++ b/patches/aeson-1.4.0.0.patch
@@ -1,0 +1,14 @@
+diff -ru aeson-1.4.0.0.orig/Data/Aeson/Types/Generic.hs aeson-1.4.0.0/Data/Aeson/Types/Generic.hs
+--- aeson-1.4.0.0.orig/Data/Aeson/Types/Generic.hs	2018-03-29 21:38:10.000000000 -0400
++++ aeson-1.4.0.0/Data/Aeson/Types/Generic.hs	2018-06-17 16:13:31.222851466 -0400
+@@ -9,6 +9,10 @@
+ {-# LANGUAGE TypeOperators #-}
+ {-# LANGUAGE UndecidableInstances #-}
+ 
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE StarIsType #-}
++#endif
++
+ #include "overlapping-compat.h"
+ 
+ -- |

--- a/patches/cassava-0.5.1.0.patch
+++ b/patches/cassava-0.5.1.0.patch
@@ -1,0 +1,14 @@
+diff -ru cassava-0.5.1.0.orig/Data/Csv/Conversion.hs cassava-0.5.1.0/Data/Csv/Conversion.hs
+--- cassava-0.5.1.0.orig/Data/Csv/Conversion.hs	2017-08-12 12:05:04.000000000 -0400
++++ cassava-0.5.1.0/Data/Csv/Conversion.hs	2018-06-17 16:12:47.854850373 -0400
+@@ -18,6 +18,10 @@
+ {-# LANGUAGE PolyKinds #-}
+ #endif
+ 
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE StarIsType #-}
++#endif
++
+ #if !MIN_VERSION_bytestring(0,10,4)
+ # define MIN_VERSION_text_short(a,b,c) 0
+ #endif

--- a/patches/cereal-0.5.5.0.patch
+++ b/patches/cereal-0.5.5.0.patch
@@ -1,0 +1,14 @@
+diff -ru cereal-0.5.5.0.orig/src/Data/Serialize.hs cereal-0.5.5.0/src/Data/Serialize.hs
+--- cereal-0.5.5.0.orig/src/Data/Serialize.hs	2018-01-22 17:50:15.000000000 -0500
++++ cereal-0.5.5.0/src/Data/Serialize.hs	2018-06-17 15:23:44.358776246 -0400
+@@ -7,6 +7,10 @@
+            , KindSignatures
+            , ScopedTypeVariables #-}
+ 
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE StarIsType #-}
++#endif
++
+ #ifndef MIN_VERSION_base
+ #define MIN_VERSION_base(x,y,z) 1
+ #endif

--- a/patches/doctest-0.15.0.patch
+++ b/patches/doctest-0.15.0.patch
@@ -1,6 +1,6 @@
 diff -ru doctest-0.15.0.orig/src/Extract.hs doctest-0.15.0/src/Extract.hs
 --- doctest-0.15.0.orig/src/Extract.hs	2018-03-13 01:00:03.000000000 -0400
-+++ doctest-0.15.0/src/Extract.hs	2018-05-07 08:57:19.407104487 -0400
++++ doctest-0.15.0/src/Extract.hs	2018-06-17 16:21:56.154864182 -0400
 @@ -151,7 +151,11 @@
          objectDir  = Just f
        , hiDir      = Just f
@@ -11,7 +11,7 @@ diff -ru doctest-0.15.0.orig/src/Extract.hs doctest-0.15.0/src/Extract.hs
        , includePaths = f : includePaths d
 +#endif
        }
-
+ 
  -- | Extract all docstrings from given list of files/modules.
 @@ -197,8 +201,10 @@
      header  = [(Nothing, x) | Just x <- [hsmodHaddockModHeader source]]
@@ -24,7 +24,7 @@ diff -ru doctest-0.15.0.orig/src/Extract.hs doctest-0.15.0/src/Extract.hs
 +    exports = [(Nothing, L loc doc) | L loc (IEDoc _ doc) <- maybe [] unLoc (hsmodExports source)]
  #endif
      decls   = extractDocStrings (hsmodDecls source)
-
+ 
 @@ -252,7 +258,12 @@
        -- Top-level documentation has to be treated separately, because it has
        -- no location information attached.  The location information is
@@ -36,6 +36,15 @@ diff -ru doctest-0.15.0.orig/src/Extract.hs doctest-0.15.0/src/Extract.hs
 +      DocD x
 +#endif
 +             -> select (fromDocDecl loc x)
-
+ 
        _ -> (extractDocStrings decl, True)
-
+ 
+@@ -269,4 +280,8 @@
+ 
+ -- | Convert a docstring to a plain string.
+ unpackDocString :: HsDocString -> String
++#if __GLASGOW_HASKELL__ >= 805
++unpackDocString = unpackHDS
++#else
+ unpackDocString (HsDocString s) = unpackFS s
++#endif

--- a/patches/hashable-1.2.7.0.patch
+++ b/patches/hashable-1.2.7.0.patch
@@ -1,0 +1,14 @@
+diff -ru hashable-1.2.7.0.orig/Data/Hashable/Generic.hs hashable-1.2.7.0/Data/Hashable/Generic.hs
+--- hashable-1.2.7.0.orig/Data/Hashable/Generic.hs	2018-03-07 17:02:09.000000000 -0500
++++ hashable-1.2.7.0/Data/Hashable/Generic.hs	2018-06-17 14:31:55.858697963 -0400
+@@ -1,6 +1,9 @@
+ {-# LANGUAGE BangPatterns, FlexibleInstances, KindSignatures,
+              ScopedTypeVariables, TypeOperators,
+-             MultiParamTypeClasses, GADTs, FlexibleContexts #-}
++             MultiParamTypeClasses, GADTs, FlexibleContexts, CPP #-}
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE StarIsType #-}
++#endif
+ {-# OPTIONS_GHC -fno-warn-orphans #-}
+ 
+ ------------------------------------------------------------------------

--- a/patches/lens-4.16.1.patch
+++ b/patches/lens-4.16.1.patch
@@ -1,0 +1,55 @@
+diff -ru lens-4.16.1.orig/src/Control/Lens/At.hs lens-4.16.1/src/Control/Lens/At.hs
+--- lens-4.16.1.orig/src/Control/Lens/At.hs	2018-03-23 08:39:38.000000000 -0400
++++ lens-4.16.1/src/Control/Lens/At.hs	2018-06-17 16:51:32.998908929 -0400
+@@ -18,6 +18,10 @@
+ {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
+ #endif
+ 
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE StarIsType #-}
++#endif
++
+ #ifndef MIN_VERSION_base
+ #define MIN_VERSION_base(x,y,z) 1
+ #endif
+diff -ru lens-4.16.1.orig/src/Control/Lens/Tuple.hs lens-4.16.1/src/Control/Lens/Tuple.hs
+--- lens-4.16.1.orig/src/Control/Lens/Tuple.hs	2018-03-23 08:39:38.000000000 -0400
++++ lens-4.16.1/src/Control/Lens/Tuple.hs	2018-06-17 16:50:14.250906945 -0400
+@@ -12,6 +12,10 @@
+ {-# LANGUAGE MultiParamTypeClasses #-}
+ {-# LANGUAGE FunctionalDependencies #-}
+ 
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE StarIsType #-}
++#endif
++
+ #ifndef MIN_VERSION_base
+ #define MIN_VERSION_base(x,y,z) 1
+ #endif
+diff -ru lens-4.16.1.orig/src/Control/Lens/Type.hs lens-4.16.1/src/Control/Lens/Type.hs
+--- lens-4.16.1.orig/src/Control/Lens/Type.hs	2018-03-23 08:39:38.000000000 -0400
++++ lens-4.16.1/src/Control/Lens/Type.hs	2018-06-17 16:49:45.874906231 -0400
+@@ -12,6 +12,9 @@
+ #if __GLASGOW_HASKELL__ >= 800
+ {-# LANGUAGE TypeInType #-}
+ #endif
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE StarIsType #-}
++#endif
+ -------------------------------------------------------------------------------
+ -- |
+ -- Module      :  Control.Lens.Type
+diff -ru lens-4.16.1.orig/src/Control/Lens/Wrapped.hs lens-4.16.1/src/Control/Lens/Wrapped.hs
+--- lens-4.16.1.orig/src/Control/Lens/Wrapped.hs	2018-03-23 08:39:38.000000000 -0400
++++ lens-4.16.1/src/Control/Lens/Wrapped.hs	2018-06-17 16:51:04.902908221 -0400
+@@ -23,6 +23,10 @@
+ {-# LANGUAGE ViewPatterns #-}
+ #endif
+ 
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE StarIsType #-}
++#endif
++
+ {-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
+ 
+ #ifndef MIN_VERSION_base

--- a/patches/profunctors-5.2.2.patch
+++ b/patches/profunctors-5.2.2.patch
@@ -1,0 +1,13 @@
+diff -ru profunctors-5.2.2.orig/src/Data/Profunctor/Rep.hs profunctors-5.2.2/src/Data/Profunctor/Rep.hs
+--- profunctors-5.2.2.orig/src/Data/Profunctor/Rep.hs	2018-01-18 15:05:00.000000000 -0500
++++ profunctors-5.2.2/src/Data/Profunctor/Rep.hs	2018-06-17 15:24:34.214777502 -0400
+@@ -9,6 +9,9 @@
+ #if __GLASGOW_HASKELL__ >= 702 && __GLASGOW_HASKELL__ <= 708
+ {-# LANGUAGE Trustworthy #-}
+ #endif
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE StarIsType #-}
++#endif
+ -----------------------------------------------------------------------------
+ -- |
+ -- Module      :  Data.Profunctor.Rep

--- a/patches/reflection-2.1.3.patch
+++ b/patches/reflection-2.1.3.patch
@@ -1,0 +1,31 @@
+diff -ru reflection-2.1.3.orig/fast/Data/Reflection.hs reflection-2.1.3/fast/Data/Reflection.hs
+--- reflection-2.1.3.orig/fast/Data/Reflection.hs	2018-01-18 19:35:38.000000000 -0500
++++ reflection-2.1.3/fast/Data/Reflection.hs	2018-06-17 16:11:06.662847825 -0400
+@@ -23,6 +23,10 @@
+ # endif
+ #endif
+ 
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE StarIsType #-}
++#endif
++
+ {-# LANGUAGE TypeFamilies #-}
+ {-# LANGUAGE DeriveDataTypeable #-}
+ {-# LANGUAGE UndecidableInstances #-}
+@@ -126,6 +130,7 @@
+ import Data.Traversable
+ #endif
+ 
++import qualified Data.Kind as Kind
+ import Data.Typeable
+ import Data.Word
+ import Foreign.Ptr
+@@ -330,7 +335,7 @@
+   a + b = AppT (AppT (VarT ''(+)) a) b
+ 
+   LitT (NumTyLit a) * LitT (NumTyLit b) = LitT (NumTyLit (a*b))
+-  (*) a b = AppT (AppT (VarT ''(*)) a) b
++  (*) a b = AppT (AppT (VarT ''(GHC.TypeLits.*)) a) b
+ #if MIN_VERSION_base(4,8,0)
+   a - b = AppT (AppT (VarT ''(-)) a) b
+ #else

--- a/patches/singletons-2.4.1.patch
+++ b/patches/singletons-2.4.1.patch
@@ -1,14 +1,33 @@
-commit 470dcb77200a60701907ad958af04e5b9e18d7a3
-Author: Ryan Scott <ryan.gl.scott@gmail.com>
-Date:   Tue Apr 3 14:45:48 2018 -0400
-
-    Allow building with template-haskell-2.14
-
-diff --git a/src/Data/Singletons/Single/Monad.hs b/src/Data/Singletons/Single/Monad.hs
-index 7da2a7b..b1928b2 100644
---- a/src/Data/Singletons/Single/Monad.hs
-+++ b/src/Data/Singletons/Single/Monad.hs
-@@ -8,7 +8,7 @@ This file defines the SgM monad and its operations, for use during singling.
+diff -ru singletons-2.4.1.orig/src/Data/Singletons/Internal.hs singletons-2.4.1/src/Data/Singletons/Internal.hs
+--- singletons-2.4.1.orig/src/Data/Singletons/Internal.hs	2018-01-08 11:09:19.000000000 -0500
++++ singletons-2.4.1/src/Data/Singletons/Internal.hs	2018-06-17 15:14:39.710762530 -0400
+@@ -88,7 +88,7 @@
+   -- | Get a base type from the promoted kind. For example,
+   -- @Demote Bool@ will be the type @Bool@. Rarely, the type and kind do not
+   -- match. For example, @Demote Nat@ is @Natural@.
+-  type Demote k = (r :: *) | r -> k
++  type Demote k = (r :: Type) | r -> k
+ 
+   -- | Convert a singleton to its unrefined version.
+   fromSing :: Sing (a :: k) -> Demote k
+@@ -167,11 +167,11 @@
+ -- between term-level arrows and this type-level arrow is that at the term
+ -- level applications can be unsaturated, whereas at the type level all
+ -- applications have to be fully saturated.
+-data TyFun :: * -> * -> *
++data TyFun :: Type -> Type -> Type
+ 
+ -- | Something of kind `a ~> b` is a defunctionalized type function that is
+ -- not necessarily generative or injective.
+-type a ~> b = TyFun a b -> *
++type a ~> b = TyFun a b -> Type
+ infixr 0 ~>
+ 
+ -- | Type level function application
+diff -ru singletons-2.4.1.orig/src/Data/Singletons/Single/Monad.hs singletons-2.4.1/src/Data/Singletons/Single/Monad.hs
+--- singletons-2.4.1.orig/src/Data/Singletons/Single/Monad.hs	2018-01-08 11:09:19.000000000 -0500
++++ singletons-2.4.1/src/Data/Singletons/Single/Monad.hs	2018-06-17 15:13:26.514760687 -0400
+@@ -8,7 +8,7 @@
  The SgM monad allows reading from a SgEnv environment and is wrapped around a Q.
  -}
  
@@ -17,7 +36,7 @@ index 7da2a7b..b1928b2 100644
  
  module Data.Singletons.Single.Monad (
    SgM, bindLets, lookupVarE, lookupConE,
-@@ -72,7 +72,12 @@ instance Quasi SgM where
+@@ -72,7 +72,12 @@
    qReifyConStrictness = liftSgM `comp1` qReifyConStrictness
    qIsExtEnabled       = liftSgM `comp1` qIsExtEnabled
    qExtsEnabled        = liftSgM qExtsEnabled
@@ -30,11 +49,40 @@ index 7da2a7b..b1928b2 100644
    qAddCorePlugin      = liftSgM `comp1` qAddCorePlugin
  
    qRecover (SgM handler) (SgM body) = do
-diff --git a/src/Data/Singletons/Util.hs b/src/Data/Singletons/Util.hs
-index f11bc7e..1a30765 100644
---- a/src/Data/Singletons/Util.hs
-+++ b/src/Data/Singletons/Util.hs
-@@ -11,7 +11,7 @@ Users of the package should not need to consult this file.
+diff -ru singletons-2.4.1.orig/src/Data/Singletons/TypeRepStar.hs singletons-2.4.1/src/Data/Singletons/TypeRepStar.hs
+--- singletons-2.4.1.orig/src/Data/Singletons/TypeRepStar.hs	2018-01-08 11:09:19.000000000 -0500
++++ singletons-2.4.1/src/Data/Singletons/TypeRepStar.hs	2018-06-17 15:15:54.770764420 -0400
+@@ -50,7 +50,7 @@
+ -- | A variant of 'SomeTypeRep' whose underlying 'TypeRep' is restricted to
+ -- kind @*@.
+ data SomeTypeRepStar where
+-  SomeTypeRepStar :: forall (a :: *). !(TypeRep a) -> SomeTypeRepStar
++  SomeTypeRepStar :: forall (a :: Type). !(TypeRep a) -> SomeTypeRepStar
+ 
+ instance Eq SomeTypeRepStar where
+   SomeTypeRepStar a == SomeTypeRepStar b =
+@@ -65,7 +65,7 @@
+ instance Show SomeTypeRepStar where
+   showsPrec p (SomeTypeRepStar ty) = showsPrec p ty
+ 
+-instance Typeable a => SingI (a :: *) where
++instance Typeable a => SingI (a :: Type) where
+   sing = STypeRep typeRep
+ instance SingKind Type where
+   type Demote Type = SomeTypeRepStar
+@@ -73,7 +73,7 @@
+   toSing (SomeTypeRepStar tr) = SomeSing $ STypeRep tr
+ 
+ instance PEq Type where
+-  type (a :: *) == (b :: *) = EqType a b
++  type (a :: Type) == (b :: Type) = EqType a b
+ 
+ type family EqType (a :: Type) (b :: Type) where
+   EqType a a = 'True
+diff -ru singletons-2.4.1.orig/src/Data/Singletons/Util.hs singletons-2.4.1/src/Data/Singletons/Util.hs
+--- singletons-2.4.1.orig/src/Data/Singletons/Util.hs	2018-01-08 11:09:19.000000000 -0500
++++ singletons-2.4.1/src/Data/Singletons/Util.hs	2018-06-17 15:13:26.514760687 -0400
+@@ -11,7 +11,7 @@
               TemplateHaskell, GeneralizedNewtypeDeriving,
               MultiParamTypeClasses, StandaloneDeriving,
               UndecidableInstances, MagicHash, UnboxedTuples,
@@ -43,7 +91,7 @@ index f11bc7e..1a30765 100644
  
  module Data.Singletons.Util where
  
-@@ -404,7 +404,12 @@ instance (Quasi q, Monoid m) => Quasi (QWithAux m q) where
+@@ -404,7 +404,12 @@
    qReifyConStrictness = lift `comp1` qReifyConStrictness
    qIsExtEnabled       = lift `comp1` qIsExtEnabled
    qExtsEnabled        = lift qExtsEnabled

--- a/patches/vector-algorithms-0.7.0.1.patch
+++ b/patches/vector-algorithms-0.7.0.1.patch
@@ -1,0 +1,16 @@
+diff -ru vector-algorithms-0.7.0.1.orig/vector-algorithms.cabal vector-algorithms-0.7.0.1/vector-algorithms.cabal
+--- vector-algorithms-0.7.0.1.orig/vector-algorithms.cabal	2015-08-12 17:47:36.000000000 -0400
++++ vector-algorithms-0.7.0.1/vector-algorithms.cabal	2018-06-17 16:38:33.070889287 -0400
+@@ -63,9 +63,11 @@
+     Data.Vector.Algorithms.Common
+ 
+   ghc-options:
+-    -Odph
+     -funbox-strict-fields
+ 
++  if !impl(ghc >= 8.5)
++    ghc-options: -Odph
++
+   include-dirs:
+     include
+ 


### PR DESCRIPTION
GHC 8.6 is looming, and with it comes many, many package breakages. Here's a handful of patches to help repair the damage:

* `StarIsType`-related breakage
  - `adjunctions`
  - `aeson`
  - `cassava`
  - `cereal`
  - `hashable`
  - `lens`
  - `profunctors`
  - `reflection`
  - `singletons`
* Adapting to the `HsDocString` constructor's removal
  - `doctest`
* Adapting to DPH's removal
  - `vector-algorithms`

cc @alanz @int-index @phadej