### PR TITLE
Adapt doctest and vector-algorithms to build with the lastest GHC HEAD

### DIFF
--- a/patches/doctest-0.15.0.patch
+++ b/patches/doctest-0.15.0.patch
@@ -1,6 +1,6 @@
 diff -ru doctest-0.15.0.orig/src/Extract.hs doctest-0.15.0/src/Extract.hs
 --- doctest-0.15.0.orig/src/Extract.hs	2018-03-13 01:00:03.000000000 -0400
-+++ doctest-0.15.0/src/Extract.hs	2018-05-07 08:57:19.407104487 -0400
++++ doctest-0.15.0/src/Extract.hs	2018-06-17 16:21:56.154864182 -0400
 @@ -151,7 +151,11 @@
          objectDir  = Just f
        , hiDir      = Just f
@@ -39,3 +39,12 @@ diff -ru doctest-0.15.0.orig/src/Extract.hs doctest-0.15.0/src/Extract.hs
 
        _ -> (extractDocStrings decl, True)
 
+@@ -269,4 +280,8 @@
+
+ -- | Convert a docstring to a plain string.
+ unpackDocString :: HsDocString -> String
++#if __GLASGOW_HASKELL__ >= 805
++unpackDocString = unpackHDS
++#else
+ unpackDocString (HsDocString s) = unpackFS s
++#endif

--- a/patches/vector-algorithms-0.7.0.1.patch
+++ b/patches/vector-algorithms-0.7.0.1.patch
@@ -1,0 +1,16 @@
+diff -ru vector-algorithms-0.7.0.1.orig/vector-algorithms.cabal vector-algorithms-0.7.0.1/vector-algorithms.cabal
+--- vector-algorithms-0.7.0.1.orig/vector-algorithms.cabal	2015-08-12 17:47:36.000000000 -0400
++++ vector-algorithms-0.7.0.1/vector-algorithms.cabal	2018-06-17 16:38:33.070889287 -0400
+@@ -63,9 +63,11 @@
+     Data.Vector.Algorithms.Common
+ 
+   ghc-options:
+-    -Odph
+     -funbox-strict-fields
+ 
++  if !impl(ghc >= 8.5)
++    ghc-options: -Odph
++
+   include-dirs:
+     include
+ 


### PR DESCRIPTION
(Split off from #61.)

`doctest` needs to be adapted to the removal of the `HsDocString` constructor.

`vector-algorithms` needs to be adapted to the removal of Data Parallel Haskell (and thus the `-Odph` flag's removal).