### PR TITLE
Some GHC 8.6.1 patches

### DIFF
--- a/patches/basement-0.0.7.patch
+++ b/patches/basement-0.0.7.patch
@@ -1,0 +1,34 @@
+diff -ru basement-0.0.7.orig/Basement/Nat.hs basement-0.0.7/Basement/Nat.hs
+--- basement-0.0.7.orig/Basement/Nat.hs	2017-11-11 04:52:31.000000000 -0500
++++ basement-0.0.7/Basement/Nat.hs	2018-06-24 17:54:55.038235612 -0400
+@@ -8,6 +8,9 @@
+ {-# LANGUAGE ScopedTypeVariables       #-}
+ {-# LANGUAGE UndecidableInstances      #-}
+ {-# LANGUAGE ConstraintKinds           #-}
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE NoStarIsType #-}
++#endif
+ module Basement.Nat
+     ( Nat
+     , KnownNat
+diff -ru basement-0.0.7.orig/Basement/Sized/Block.hs basement-0.0.7/Basement/Sized/Block.hs
+--- basement-0.0.7.orig/Basement/Sized/Block.hs	2018-02-12 09:24:12.000000000 -0500
++++ basement-0.0.7/Basement/Sized/Block.hs	2018-06-24 17:56:02.506237311 -0400
+@@ -5,13 +5,16 @@
+ --
+ -- A Nat-sized version of Block
+ {-# LANGUAGE AllowAmbiguousTypes        #-}
++{-# LANGUAGE CPP                        #-}
+ {-# LANGUAGE DataKinds                  #-}
+ {-# LANGUAGE TypeOperators              #-}
+ {-# LANGUAGE TypeApplications           #-}
+ {-# LANGUAGE ScopedTypeVariables        #-}
+ {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+ {-# LANGUAGE ConstraintKinds            #-}
+-
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE NoStarIsType #-}
++#endif
+ module Basement.Sized.Block
+     ( BlockN
+     , MutableBlockN

--- a/patches/constraints-0.10.patch
+++ b/patches/constraints-0.10.patch
@@ -1,0 +1,13 @@
+diff -ru constraints-0.10.orig/src/Data/Constraint/Nat.hs constraints-0.10/src/Data/Constraint/Nat.hs
+--- constraints-0.10.orig/src/Data/Constraint/Nat.hs	2018-01-18 14:26:31.000000000 -0500
++++ constraints-0.10/src/Data/Constraint/Nat.hs	2018-06-24 18:17:26.938269657 -0400
+@@ -10,6 +10,9 @@
+ {-# LANGUAGE ScopedTypeVariables #-}
+ {-# LANGUAGE AllowAmbiguousTypes #-}
+ {-# LANGUAGE Trustworthy #-}
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE NoStarIsType #-}
++#endif
+ -- | Utilities for working with 'KnownNat' constraints.
+ --
+ -- This module is only available on GHC 8.0 or later.

--- a/patches/memory-0.14.16.patch
+++ b/patches/memory-0.14.16.patch
@@ -1,0 +1,14 @@
+diff -ru memory-0.14.16.orig/Data/ByteArray/Sized.hs memory-0.14.16/Data/ByteArray/Sized.hs
+--- memory-0.14.16.orig/Data/ByteArray/Sized.hs	2018-02-26 05:46:08.000000000 -0500
++++ memory-0.14.16/Data/ByteArray/Sized.hs	2018-06-24 17:59:32.450242598 -0400
+@@ -21,7 +21,9 @@
+ {-# LANGUAGE MultiParamTypeClasses #-}
+ {-# LANGUAGE FunctionalDependencies #-}
+ {-# LANGUAGE UndecidableInstances #-}
+-
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE NoStarIsType #-}
++#endif
+ module Data.ByteArray.Sized
+     ( ByteArrayN(..)
+     , SizedByteArray

--- a/patches/reflection-2.1.3.patch
+++ b/patches/reflection-2.1.3.patch
@@ -1,0 +1,12 @@
+diff -ru reflection-2.1.3.orig/fast/Data/Reflection.hs reflection-2.1.3/fast/Data/Reflection.hs
+--- reflection-2.1.3.orig/fast/Data/Reflection.hs	2018-01-18 19:35:38.000000000 -0500
++++ reflection-2.1.3/fast/Data/Reflection.hs	2018-06-24 17:43:32.206218416 -0400
+@@ -330,7 +330,7 @@
+   a + b = AppT (AppT (VarT ''(+)) a) b
+ 
+   LitT (NumTyLit a) * LitT (NumTyLit b) = LitT (NumTyLit (a*b))
+-  (*) a b = AppT (AppT (VarT ''(*)) a) b
++  (*) a b = AppT (AppT (VarT ''(GHC.TypeLits.*)) a) b
+ #if MIN_VERSION_base(4,8,0)
+   a - b = AppT (AppT (VarT ''(-)) a) b
+ #else

--- a/patches/singletons-2.4.1.patch
+++ b/patches/singletons-2.4.1.patch
@@ -1,8 +1,12 @@
-commit 470dcb77200a60701907ad958af04e5b9e18d7a3
+commit 6eb213390729706e1840eaa67124caf26ac839f3
 Author: Ryan Scott <ryan.gl.scott@gmail.com>
 Date:   Tue Apr 3 14:45:48 2018 -0400
 
     Allow building with template-haskell-2.14
+    
+    This requires adding some CPP to temporarily support two versions of
+    GHC (8.4 and HEAD). I'll file an issue as a reminder to remove this
+    CPP once we drop support for GHC 8.4.
 
 diff --git a/src/Data/Singletons/Single/Monad.hs b/src/Data/Singletons/Single/Monad.hs
 index 7da2a7b..b1928b2 100644
@@ -31,7 +35,7 @@ index 7da2a7b..b1928b2 100644
  
    qRecover (SgM handler) (SgM body) = do
 diff --git a/src/Data/Singletons/Util.hs b/src/Data/Singletons/Util.hs
-index f11bc7e..1a30765 100644
+index 271ade3..fb64fad 100644
 --- a/src/Data/Singletons/Util.hs
 +++ b/src/Data/Singletons/Util.hs
 @@ -11,7 +11,7 @@ Users of the package should not need to consult this file.
@@ -43,7 +47,7 @@ index f11bc7e..1a30765 100644
  
  module Data.Singletons.Util where
  
-@@ -404,7 +404,12 @@ instance (Quasi q, Monoid m) => Quasi (QWithAux m q) where
+@@ -417,7 +417,12 @@ instance (Quasi q, Monoid m) => Quasi (QWithAux m q) where
    qReifyConStrictness = lift `comp1` qReifyConStrictness
    qIsExtEnabled       = lift `comp1` qIsExtEnabled
    qExtsEnabled        = lift qExtsEnabled
@@ -56,3 +60,29 @@ index f11bc7e..1a30765 100644
    qAddCorePlugin      = lift `comp1` qAddCorePlugin
  
    qRecover exp handler = do
+
+commit ddd353afa3c92a53c00f22919611f734eaa0f29f
+Author: Ryan Scott <ryan.gl.scott@gmail.com>
+Date:   Sat Jun 30 18:51:48 2018 -0400
+
+    PNum(type (*)) requires NoStarIsType
+    
+    This requires adding some CPP to temporarily support two versions of
+    GHC (8.4 and HEAD). I'll amend #324 as a reminder to remove this
+    CPP once we drop support for GHC 8.4.
+
+diff --git a/src/Data/Singletons/Prelude/Num.hs b/src/Data/Singletons/Prelude/Num.hs
+index 9381afc..f1d00ab 100644
+--- a/src/Data/Singletons/Prelude/Num.hs
++++ b/src/Data/Singletons/Prelude/Num.hs
+@@ -2,6 +2,10 @@
+              TypeOperators, GADTs, ScopedTypeVariables, UndecidableInstances,
+              DefaultSignatures, FlexibleContexts, InstanceSigs
+   #-}
++{-# LANGUAGE CPP #-}
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE NoStarIsType #-}
++#endif
+ 
+ -----------------------------------------------------------------------------
+ -- |

--- a/patches/tasty-1.1.0.2.patch
+++ b/patches/tasty-1.1.0.2.patch
@@ -1,0 +1,36 @@
+diff -ru tasty-1.1.0.2.orig/Test/Tasty/CmdLine.hs tasty-1.1.0.2/Test/Tasty/CmdLine.hs
+--- tasty-1.1.0.2.orig/Test/Tasty/CmdLine.hs	2018-02-12 13:46:24.000000000 -0500
++++ tasty-1.1.0.2/Test/Tasty/CmdLine.hs	2018-06-30 18:36:35.559353670 -0400
+@@ -8,7 +8,7 @@
+   ) where
+ 
+ import Options.Applicative
+-import Data.Monoid
++import Data.Monoid (Monoid(..), (<>))
+ import Data.Proxy
+ import Data.Foldable (foldMap)
+ import Prelude  -- Silence AMP and FTP import warnings
+diff -ru tasty-1.1.0.2.orig/Test/Tasty/Ingredients/ConsoleReporter.hs tasty-1.1.0.2/Test/Tasty/Ingredients/ConsoleReporter.hs
+--- tasty-1.1.0.2.orig/Test/Tasty/Ingredients/ConsoleReporter.hs	2018-06-23 09:22:35.000000000 -0400
++++ tasty-1.1.0.2/Test/Tasty/Ingredients/ConsoleReporter.hs	2018-06-30 18:37:05.631354427 -0400
+@@ -41,7 +41,7 @@
+ import Data.Char.WCWidth (wcwidth)
+ #endif
+ import Data.Maybe
+-import Data.Monoid
++import Data.Monoid (Monoid(..), Any(..))
+ import Data.Typeable
+ import Options.Applicative hiding (str)
+ import System.IO
+diff -ru tasty-1.1.0.2.orig/Test/Tasty/Runners/Reducers.hs tasty-1.1.0.2/Test/Tasty/Runners/Reducers.hs
+--- tasty-1.1.0.2.orig/Test/Tasty/Runners/Reducers.hs	2018-05-06 09:28:51.000000000 -0400
++++ tasty-1.1.0.2/Test/Tasty/Runners/Reducers.hs	2018-06-30 18:35:50.635352539 -0400
+@@ -41,7 +41,7 @@
+ 
+ module Test.Tasty.Runners.Reducers where
+ 
+-import Data.Monoid
++import Data.Monoid (Monoid(..))
+ import Control.Applicative
+ import Prelude  -- Silence AMP import warnings
+ #if MIN_VERSION_base(4,9,0)


### PR DESCRIPTION
Now that GHC 8.6.1-alpha1 is out, I've cooked up a fresh batch of patches:

* Adapting to `StarIsType`:
  * `basement`
  * `constraints`
  * `memory`
  * `reflection`
  * `singletons`
* Adapting to `Data.Monoid.Ap`
  * `tasty`