### PR TITLE
Even more GHC 8.6.1-related patches

### DIFF
--- a/patches/Unixutils-1.54.1.patch
+++ b/patches/Unixutils-1.54.1.patch
@@ -1,0 +1,22 @@
+diff -ru Unixutils-1.54.1.orig/System/Unix/Chroot.hs Unixutils-1.54.1/System/Unix/Chroot.hs
+--- Unixutils-1.54.1.orig/System/Unix/Chroot.hs	2015-08-11 16:02:44.000000000 -0400
++++ Unixutils-1.54.1/System/Unix/Chroot.hs	2018-07-04 21:18:53.544302297 -0400
+@@ -1,4 +1,4 @@
+-{-# LANGUAGE ForeignFunctionInterface #-}
++{-# LANGUAGE CPP, ForeignFunctionInterface #-}
+ -- | This module, except for useEnv, is copied from the build-env package.
+ module System.Unix.Chroot
+     ( fchroot
+@@ -45,7 +45,11 @@
+ fchroot :: (MonadIO m, MonadMask m) => FilePath -> m a -> m a
+ fchroot path action =
+     do origWd <- liftIO $ getWorkingDirectory
+-       rootFd <- liftIO $ openFd "/" ReadOnly Nothing defaultFileFlags
++       rootFd <- liftIO $ openFd "/" ReadOnly
++#if !(MIN_VERSION_unix(2,8,0))
++                                 Nothing
++#endif
++                                 defaultFileFlags
+        liftIO $ chroot path
+        liftIO $ changeWorkingDirectory "/"
+        action `finally` (liftIO $ breakFree origWd rootFd)

--- a/patches/accelerate-1.2.0.0.patch
+++ b/patches/accelerate-1.2.0.0.patch
@@ -1,0 +1,33 @@
+diff -ru accelerate-1.2.0.0.orig/src/Data/Array/Accelerate/Data/Monoid.hs accelerate-1.2.0.0/src/Data/Array/Accelerate/Data/Monoid.hs
+--- accelerate-1.2.0.0.orig/src/Data/Array/Accelerate/Data/Monoid.hs	2018-03-20 23:21:17.000000000 -0400
++++ accelerate-1.2.0.0/src/Data/Array/Accelerate/Data/Monoid.hs	2018-07-04 21:51:33.816351664 -0400
+@@ -5,6 +5,7 @@
+ {-# LANGUAGE MultiParamTypeClasses #-}
+ {-# LANGUAGE ScopedTypeVariables   #-}
+ {-# LANGUAGE TypeFamilies          #-}
++{-# LANGUAGE UndecidableInstances  #-}
+ {-# OPTIONS_GHC -fno-warn-orphans #-}
+ -- |
+ -- Module      : Data.Array.Accelerate.Data.Monoid
+diff -ru accelerate-1.2.0.0.orig/src/Data/Array/Accelerate/Data/Semigroup.hs accelerate-1.2.0.0/src/Data/Array/Accelerate/Data/Semigroup.hs
+--- accelerate-1.2.0.0.orig/src/Data/Array/Accelerate/Data/Semigroup.hs	2018-03-19 00:08:29.000000000 -0400
++++ accelerate-1.2.0.0/src/Data/Array/Accelerate/Data/Semigroup.hs	2018-07-04 21:51:12.028351115 -0400
+@@ -5,6 +5,7 @@
+ {-# LANGUAGE RebindableSyntax      #-}
+ {-# LANGUAGE ScopedTypeVariables   #-}
+ {-# LANGUAGE TypeFamilies          #-}
++{-# LANGUAGE UndecidableInstances  #-}
+ {-# LANGUAGE ViewPatterns          #-}
+ {-# OPTIONS_GHC -fno-warn-orphans #-}
+ -- |
+diff -ru accelerate-1.2.0.0.orig/src/Data/Array/Accelerate/Lift.hs accelerate-1.2.0.0/src/Data/Array/Accelerate/Lift.hs
+--- accelerate-1.2.0.0.orig/src/Data/Array/Accelerate/Lift.hs	2018-03-19 00:08:29.000000000 -0400
++++ accelerate-1.2.0.0/src/Data/Array/Accelerate/Lift.hs	2018-07-04 21:50:26.520349969 -0400
+@@ -4,6 +4,7 @@
+ {-# LANGUAGE MultiParamTypeClasses #-}
+ {-# LANGUAGE TypeFamilies          #-}
+ {-# LANGUAGE TypeOperators         #-}
++{-# LANGUAGE UndecidableInstances  #-}
+ #if __GLASGOW_HASKELL__ <= 708
+ {-# LANGUAGE OverlappingInstances  #-}
+ {-# OPTIONS_GHC -fno-warn-unrecognised-pragmas #-}

--- a/patches/cipher-aes128-0.7.0.3.patch
+++ b/patches/cipher-aes128-0.7.0.3.patch
@@ -1,0 +1,16 @@
+diff -ru cipher-aes128-0.7.0.3.orig/Setup.hs cipher-aes128-0.7.0.3/Setup.hs
+--- cipher-aes128-0.7.0.3.orig/Setup.hs	2016-08-31 01:58:48.000000000 -0400
++++ cipher-aes128-0.7.0.3/Setup.hs	2018-07-04 22:06:10.880373751 -0400
+@@ -13,10 +13,8 @@
+ main = defaultMainWithHooks hk
+  where
+  hk = simpleUserHooks { buildHook = \pd lbi uh bf -> do
+-                                        let ccProg = Program "gcc" undefined undefined undefined
+-                                            hcProg = Program "ghc" undefined undefined undefined
+-                                            mConf  = lookupProgram ccProg (withPrograms lbi)
+-                                            hcConf = lookupProgram hcProg (withPrograms lbi)
++                                        let mConf  = lookupProgram gccProgram (withPrograms lbi)
++                                            hcConf = lookupProgram ghcProgram (withPrograms lbi)
+                                             err = error "Could not determine C compiler"
+                                             _cc  = locationPath . programLocation  . maybe err id $ mConf
+                                             hc  = locationPath . programLocation  . maybe err id $ hcConf

--- a/patches/hslogger-1.2.10.patch
+++ b/patches/hslogger-1.2.10.patch
@@ -1,0 +1,12 @@
+diff -ru hslogger-1.2.10.orig/src/System/Log/Logger.hs hslogger-1.2.10/src/System/Log/Logger.hs
+--- hslogger-1.2.10.orig/src/System/Log/Logger.hs	2016-05-29 09:42:33.000000000 -0400
++++ hslogger-1.2.10/src/System/Log/Logger.hs	2018-07-04 21:47:31.436345560 -0400
+@@ -476,7 +476,7 @@
+ removeAllHandlers :: IO ()
+ removeAllHandlers =
+     modifyMVar_ logTree $ \lt -> do
+-        let allHandlers = Map.fold (\l r -> concat [r, handlers l]) [] lt
++        let allHandlers = Map.foldr (\l r -> concat [r, handlers l]) [] lt
+         mapM_ (\(HandlerT h) -> close h) allHandlers
+         return $ Map.map (\l -> l {handlers = []}) lt
+ 

--- a/patches/ixset-1.1.patch
+++ b/patches/ixset-1.1.patch
@@ -1,0 +1,20 @@
+diff -ru ixset-1.1.orig/src/Data/IxSet/Ix.hs ixset-1.1/src/Data/IxSet/Ix.hs
+--- ixset-1.1.orig/src/Data/IxSet/Ix.hs	2018-05-28 12:25:24.000000000 -0400
++++ ixset-1.1/src/Data/IxSet/Ix.hs	2018-07-04 21:43:13.920339074 -0400
+@@ -24,6 +24,7 @@
+ import           Data.List  (foldl')
+ import           Data.Map   (Map)
+ import qualified Data.Map   as Map
++import qualified Data.Map.Strict as MapS
+ import           Data.Set   (Set)
+ import qualified Data.Set   as Set
+ 
+@@ -66,7 +67,7 @@
+ -- 'Map', then a new 'Set' is added transparently.
+ insert :: (Ord a, Ord k)
+        => k -> a -> Map k (Set a) -> Map k (Set a)
+-insert k v index = Map.insertWith' Set.union k (Set.singleton v) index
++insert k v index = MapS.insertWith Set.union k (Set.singleton v) index
+ 
+ -- | Helper function to 'insert' a list of elements into a set.
+ insertList :: (Ord a, Ord k)

--- a/patches/ixset-typed-0.4.patch
+++ b/patches/ixset-typed-0.4.patch
@@ -1,0 +1,20 @@
+diff -ru ixset-typed-0.4.orig/src/Data/IxSet/Typed/Ix.hs ixset-typed-0.4/src/Data/IxSet/Typed/Ix.hs
+--- ixset-typed-0.4.orig/src/Data/IxSet/Typed/Ix.hs	2018-03-18 07:52:09.000000000 -0400
++++ ixset-typed-0.4/src/Data/IxSet/Typed/Ix.hs	2018-07-04 21:44:42.192341297 -0400
+@@ -27,6 +27,7 @@
+ import qualified Data.List  as List
+ import           Data.Map   (Map)
+ import qualified Data.Map   as Map
++import qualified Data.Map.Strict as MapS
+ import           Data.Set   (Set)
+ import qualified Data.Set   as Set
+ 
+@@ -80,7 +81,7 @@
+ -- 'Map', then a new 'Set' is added transparently.
+ insert :: (Ord a, Ord k)
+        => k -> a -> Map k (Set a) -> Map k (Set a)
+-insert k v index = Map.insertWith' Set.union k (Set.singleton v) index
++insert k v index = MapS.insertWith Set.union k (Set.singleton v) index
+ 
+ -- | Helper function to 'insert' a list of elements into a set.
+ insertList :: (Ord a, Ord k)

--- a/patches/language-c-0.8.1.patch
+++ b/patches/language-c-0.8.1.patch
@@ -1,0 +1,24 @@
+diff -ru language-c-0.8.1.orig/src/Language/C/Analysis/DefTable.hs language-c-0.8.1/src/Language/C/Analysis/DefTable.hs
+--- language-c-0.8.1.orig/src/Language/C/Analysis/DefTable.hs	2018-06-08 00:48:29.000000000 -0400
++++ language-c-0.8.1/src/Language/C/Analysis/DefTable.hs	2018-07-04 21:30:47.308320272 -0400
+@@ -106,7 +106,7 @@
+ 
+ -- | get the globally defined entries of a definition table
+ globalDefs :: DefTable -> GlobalDecls
+-globalDefs deftbl = Map.foldWithKey insertDecl (GlobalDecls e gtags e) (globalNames $ identDecls deftbl)
++globalDefs deftbl = Map.foldrWithKey insertDecl (GlobalDecls e gtags e) (globalNames $ identDecls deftbl)
+     where
+     e = Map.empty
+     (_fwd_decls,gtags) = Map.mapEither id $ globalNames (tagDecls deftbl)
+diff -ru language-c-0.8.1.orig/src/Language/C/Analysis/SemRep.hs language-c-0.8.1/src/Language/C/Analysis/SemRep.hs
+--- language-c-0.8.1.orig/src/Language/C/Analysis/SemRep.hs	2018-06-08 00:48:29.000000000 -0400
++++ language-c-0.8.1/src/Language/C/Analysis/SemRep.hs	2018-07-04 21:30:29.036319812 -0400
+@@ -136,7 +136,7 @@
+                                                 ( Map Ident Enumerator,
+                                                   Map Ident ObjDef,
+                                                   Map Ident FunDef ) )
+-splitIdentDecls include_all = Map.foldWithKey (if include_all then deal else deal') (Map.empty,(Map.empty,Map.empty,Map.empty))
++splitIdentDecls include_all = Map.foldrWithKey (if include_all then deal else deal') (Map.empty,(Map.empty,Map.empty,Map.empty))
+   where
+   deal ident entry (decls,defs) = (Map.insert ident (declOfDef entry) decls, addDef ident entry defs)
+   deal' ident (Declaration d) (decls,defs) = (Map.insert ident d decls,defs)

--- a/patches/numtype-dk-0.5.0.1.patch
+++ b/patches/numtype-dk-0.5.0.1.patch
@@ -1,0 +1,48 @@
+diff -ru numtype-dk-0.5.0.1.orig/Numeric/NumType/DK/Integers.hs numtype-dk-0.5.0.1/Numeric/NumType/DK/Integers.hs
+--- numtype-dk-0.5.0.1.orig/Numeric/NumType/DK/Integers.hs	2016-05-16 09:14:04.000000000 -0400
++++ numtype-dk-0.5.0.1/Numeric/NumType/DK/Integers.hs	2018-07-04 21:27:12.448314861 -0400
+@@ -7,6 +7,9 @@
+ {-# LANGUAGE TypeFamilies #-}
+ {-# LANGUAGE TypeOperators #-}
+ {-# LANGUAGE UndecidableInstances #-}
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE NoStarIsType #-}
++#endif
+ 
+ {- |
+    Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
+@@ -20,7 +23,7 @@
+ 
+ Type-level integers for GHC 7.8+.
+ 
+-We provide type level arithmetic operations. We also provide term-level arithmetic operations on proxys, 
++We provide type level arithmetic operations. We also provide term-level arithmetic operations on proxys,
+ and conversion from the type level to the term level.
+ 
+ = Planned Obsolesence
+@@ -268,7 +271,7 @@
+ -- | TypeInt division.
+ type family (i::TypeInt) / (i'::TypeInt) :: TypeInt
+   where
+- 
++
+     i / 'Pos1 = i
+     i / 'Neg1 = Negate i
+     -- @Zero / n = Zero@ would allow division by zero.
+diff -ru numtype-dk-0.5.0.1.orig/Numeric/NumType/DK/Naturals.hs numtype-dk-0.5.0.1/Numeric/NumType/DK/Naturals.hs
+--- numtype-dk-0.5.0.1.orig/Numeric/NumType/DK/Naturals.hs	2015-05-11 09:10:15.000000000 -0400
++++ numtype-dk-0.5.0.1/Numeric/NumType/DK/Naturals.hs	2018-07-04 21:27:41.472315592 -0400
+@@ -1,9 +1,13 @@
+ {-# LANGUAGE AutoDeriveTypeable #-}
++{-# LANGUAGE CPP #-}
+ {-# LANGUAGE DataKinds #-}
+ {-# LANGUAGE FlexibleInstances #-}
+ {-# LANGUAGE TypeFamilies #-}
+ {-# LANGUAGE TypeOperators #-}
+ {-# LANGUAGE UndecidableInstances #-}
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE NoStarIsType #-}
++#endif
+ 
+ module Numeric.NumType.DK.Naturals where
+ 

--- a/patches/protolude-0.2.2.patch
+++ b/patches/protolude-0.2.2.patch
@@ -1,0 +1,30 @@
+diff -ru protolude-0.2.2.orig/src/Protolude/Base.hs protolude-0.2.2/src/Protolude/Base.hs
+--- protolude-0.2.2.orig/src/Protolude/Base.hs	2018-02-05 11:35:26.000000000 -0500
++++ protolude-0.2.2/src/Protolude/Base.hs	2018-07-04 21:24:34.620310887 -0400
+@@ -122,8 +122,10 @@
+ 
+ #if ( __GLASGOW_HASKELL__ >= 800 )
+ import Data.Kind as X (
+-    type (*)
+-  , type Type
++# if __GLASGOW_HASKELL__ < 805
++    type (*),
++# endif
++    type Type
+   )
+ #endif
+ 
+diff -ru protolude-0.2.2.orig/src/Protolude.hs protolude-0.2.2/src/Protolude.hs
+--- protolude-0.2.2.orig/src/Protolude.hs	2018-03-26 06:36:35.000000000 -0400
++++ protolude-0.2.2/src/Protolude.hs	2018-07-04 21:24:25.504310657 -0400
+@@ -492,8 +492,10 @@
+ import Control.Monad.STM as X (
+     STM
+   , atomically
++#if !(MIN_VERSION_stm(2,5,0))
+   , always
+   , alwaysSucceeds
++#endif
+   , retry
+   , orElse
+   , check


### PR DESCRIPTION
Categorized by the reasons they break on GHC 8.6.1:

* `UndecidableInstances` is picker on 8.6
  * `accelerate`
* `Cabal-2.5` API changes
  * `cipher-aes128`
* `containers-0.6` API changes
  * `ixset`
  * `ixset-typed`
  * `language-c`
* `StarIsType` and `stm-2.5` API changes
  * `numtype-dk`
  * `protolude`
* `unix-2.8` API changes
  * `Unixutils`