### PR TITLE
Three more GHC 8.6-related patches

### DIFF
--- a/patches/exact-pi-0.4.1.3.patch
+++ b/patches/exact-pi-0.4.1.3.patch
@@ -1,0 +1,46 @@
+diff -ru exact-pi-0.4.1.3.orig/src/Data/ExactPi/TypeLevel.hs exact-pi-0.4.1.3/src/Data/ExactPi/TypeLevel.hs
+--- exact-pi-0.4.1.3.orig/src/Data/ExactPi/TypeLevel.hs	2018-01-30 16:41:26.000000000 -0500
++++ exact-pi-0.4.1.3/src/Data/ExactPi/TypeLevel.hs	2018-07-09 10:39:23.714215253 -0400
+@@ -1,12 +1,16 @@
+ {-# OPTIONS_HADDOCK show-extensions #-}
+ 
+ {-# LANGUAGE ConstraintKinds #-}
++{-# LANGUAGE CPP #-}
+ {-# LANGUAGE DataKinds #-}
+ {-# LANGUAGE FlexibleContexts #-}
+ {-# LANGUAGE KindSignatures #-}
+ {-# LANGUAGE ScopedTypeVariables #-}
+ {-# LANGUAGE TypeFamilies #-}
+ {-# LANGUAGE TypeOperators #-}
++#if __GLASGOW_HASKELL__ >= 805
++{-# LANGUAGE NoStarIsType #-}
++#endif
+ 
+ {-|
+ Module      : Data.ExactPi.TypeLevel
+@@ -34,6 +38,7 @@
+ where
+ 
+ import Data.ExactPi
++import Data.Kind (Type)
+ import Data.Maybe (fromJust)
+ import Data.Proxy
+ import Data.Ratio
+@@ -69,7 +74,7 @@
+ 
+ -- | Determines the minimum context required for a numeric type to hold the value
+ -- associated with a specific 'ExactPi'' type.
+-type family MinCtxt' (v :: ExactPi') :: * -> Constraint where
++type family MinCtxt' (v :: ExactPi') :: Type -> Constraint where
+   MinCtxt' ('ExactPi' 'Zero p 1) = Num
+   MinCtxt' ('ExactPi' 'Zero p q) = Fractional
+   MinCtxt' ('ExactPi' z p q)     = Floating
+@@ -78,7 +83,7 @@
+ 
+ -- | A KnownMinCtxt is a contraint on values sufficient to allow us to inject certain
+ -- 'ExactPi' values into types that satisfy the constraint.
+-class KnownMinCtxt (c :: * -> Constraint) where
++class KnownMinCtxt (c :: Type -> Constraint) where
+   -- | Injects an 'ExactPi' value into a specified type satisfying this constraint.
+   -- 
+   -- The injection is permitted to fail if type constraint does not entail the 'MinCtxt'

--- a/patches/multiset-0.3.4.patch
+++ b/patches/multiset-0.3.4.patch
@@ -1,0 +1,37 @@
+diff -ru multiset-0.3.4.orig/Data/IntMultiSet.hs multiset-0.3.4/Data/IntMultiSet.hs
+--- multiset-0.3.4.orig/Data/IntMultiSet.hs	2018-05-28 16:34:34.000000000 -0400
++++ multiset-0.3.4/Data/IntMultiSet.hs	2018-07-09 11:14:01.674267583 -0400
+@@ -146,6 +146,7 @@
+ import Data.IntSet (IntSet)
+ import Data.MultiSet (MultiSet)
+ import qualified Data.IntMap.Strict as Map
++import qualified Data.IntMap.Internal.Debug as MapDebug
+ import qualified Data.IntSet as Set
+ import qualified Data.List as List
+ import qualified Data.MultiSet as MultiSet
+@@ -771,4 +772,4 @@
+ 
+ -}
+ showTreeWith :: Bool -> Bool -> IntMultiSet -> String
+-showTreeWith hang wide = Map.showTreeWith hang wide . unMS
++showTreeWith hang wide = MapDebug.showTreeWith hang wide . unMS
+diff -ru multiset-0.3.4.orig/Data/MultiSet.hs multiset-0.3.4/Data/MultiSet.hs
+--- multiset-0.3.4.orig/Data/MultiSet.hs	2018-05-28 16:34:34.000000000 -0400
++++ multiset-0.3.4/Data/MultiSet.hs	2018-07-09 11:13:33.618266876 -0400
+@@ -152,6 +152,7 @@
+ import Data.Map.Strict (Map)
+ import Data.Set (Set)
+ import qualified Data.Map.Strict as Map
++import qualified Data.Map.Internal.Debug as MapDebug
+ import qualified Data.Set as Set
+ import qualified Data.List as List
+ import Control.DeepSeq (NFData(..))
+@@ -762,7 +763,7 @@
+ 
+ -}
+ showTreeWith :: Show a => Bool -> Bool -> MultiSet a -> String
+-showTreeWith hang wide = Map.showTreeWith s hang wide . unMS
++showTreeWith hang wide = MapDebug.showTreeWith s hang wide . unMS
+   where s a n = showChar '(' . shows n . showString "*)" . shows a $ ""
+ 
+ {--------------------------------------------------------------------

--- a/patches/vector-space-0.13.patch
+++ b/patches/vector-space-0.13.patch
@@ -1,0 +1,10 @@
+diff -ru vector-space-0.13.orig/src/Data/Cross.hs vector-space-0.13/src/Data/Cross.hs
+--- vector-space-0.13.orig/src/Data/Cross.hs	2018-01-25 15:08:37.000000000 -0500
++++ vector-space-0.13/src/Data/Cross.hs	2018-07-09 11:31:01.810293273 -0400
+@@ -1,5 +1,5 @@
+ {-# LANGUAGE FlexibleInstances, FlexibleContexts, TypeOperators
+-           , TypeFamilies, TypeSynonymInstances  #-}
++           , TypeFamilies, TypeSynonymInstances, UndecidableInstances  #-}
+ {-# OPTIONS_GHC -Wall #-}
+ ----------------------------------------------------------------------
+ -- |


### PR DESCRIPTION
* `exact-pi` (`StarIsType`)
* `multiset` (`containers-0.6` API changes)
* `vector-space` (`UndecidableInstances` is pickier)