### PR TITLE
primitive 'GHC.Prim' -> 'GHC.Exts'

### DIFF
--- a/patches/primitive-0.6.4.0.patch
+++ b/patches/primitive-0.6.4.0.patch
@@ -1,0 +1,30 @@
+From a2af610c08c5f5afc496f907bf6b2a4b8da6a665 Mon Sep 17 00:00:00 2001
+From: Shao Cheng <astrohavoc@gmail.com>
+Date: Tue, 17 Jul 2018 17:17:27 +0800
+Subject: Fix compilation error by recent ghc-head (#187)
+
+---
+ Data/Primitive/MutVar.hs | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/Data/Primitive/MutVar.hs b/Data/Primitive/MutVar.hs
+index f707bfb..04993fa 100644
+--- a/Data/Primitive/MutVar.hs
++++ b/Data/Primitive/MutVar.hs
+@@ -25,7 +25,7 @@ module Data.Primitive.MutVar (
+ ) where
+ 
+ import Control.Monad.Primitive ( PrimMonad(..), primitive_ )
+-import GHC.Prim ( MutVar#, sameMutVar#, newMutVar#,
++import GHC.Exts ( MutVar#, sameMutVar#, newMutVar#,
+                   readMutVar#, writeMutVar#, atomicModifyMutVar# )
+ import Data.Primitive.Internal.Compat ( isTrue# )
+ import Data.Typeable ( Typeable )
+@@ -83,4 +83,3 @@ modifyMutVar' :: PrimMonad m => MutVar (PrimState m) a -> (a -> a) -> m ()
+ modifyMutVar' (MutVar mv#) g = primitive_ $ \s# ->
+   case readMutVar# mv# s# of
+     (# s'#, a #) -> let a' = g a in a' `seq` writeMutVar# mv# a' s'#
+-
+-- 
+2.14.3 (Apple Git-98)
+


### PR DESCRIPTION
This is holding up Haddock's CI for `ghc-head`.

cc @sjakobi @alexbiehl.