### PR TITLE
Update .cabal files for cassava, primitive

### DIFF
--- a/patches/cassava-0.5.1.0.cabal
+++ b/patches/cassava-0.5.1.0.cabal
@@ -1,6 +1,7 @@
 cabal-version:       1.12
 Name:                cassava
 Version:             0.5.1.0
+x-revision: 1
 Synopsis:            A CSV parsing and encoding library
 Description: {
 
@@ -98,7 +99,7 @@ Library
     attoparsec >= 0.11.3.0 && < 0.14,
     base >= 4.5 && < 5,
     bytestring >= 0.9.2 && < 0.11,
-    containers >= 0.4.2 && < 0.6,
+    containers >= 0.4.2 && < 0.7,
     deepseq >= 1.1 && < 1.5,
     hashable < 1.3,
     scientific >= 0.3.4.7 && < 0.4,

--- a/patches/primitive-0.6.4.0.cabal
+++ b/patches/primitive-0.6.4.0.cabal
@@ -1,0 +1,74 @@
+Name:           primitive
+Version:        0.6.4.0
+x-revision: 1
+License:        BSD3
+License-File:   LICENSE
+
+Author:         Roman Leshchinskiy <rl@cse.unsw.edu.au>
+Maintainer:     libraries@haskell.org
+Copyright:      (c) Roman Leshchinskiy 2009-2012
+Homepage:       https://github.com/haskell/primitive
+Bug-Reports:    https://github.com/haskell/primitive/issues
+Category:       Data
+Synopsis:       Primitive memory-related operations
+Cabal-Version:  >= 1.10
+Build-Type:     Simple
+Description:    This package provides various primitive memory-related operations.
+
+Extra-Source-Files: changelog.md
+                    test/*.hs
+                    test/LICENSE
+                    test/primitive-tests.cabal
+
+Tested-With:
+  GHC == 7.4.2,
+  GHC == 7.6.3,
+  GHC == 7.8.4,
+  GHC == 7.10.3,
+  GHC == 8.0.2,
+  GHC == 8.2.2,
+  GHC == 8.4.2
+
+Library
+  Default-Language: Haskell2010
+  Other-Extensions:
+        BangPatterns, CPP, DeriveDataTypeable,
+        MagicHash, TypeFamilies, UnboxedTuples, UnliftedFFITypes
+
+  Exposed-Modules:
+        Control.Monad.Primitive
+        Data.Primitive
+        Data.Primitive.MachDeps
+        Data.Primitive.Types
+        Data.Primitive.Array
+        Data.Primitive.ByteArray
+        Data.Primitive.PrimArray
+        Data.Primitive.SmallArray
+        Data.Primitive.UnliftedArray
+        Data.Primitive.Addr
+        Data.Primitive.Ptr
+        Data.Primitive.MutVar
+        Data.Primitive.MVar
+
+  Other-Modules:
+        Data.Primitive.Internal.Compat
+        Data.Primitive.Internal.Operations
+
+  Build-Depends: base >= 4.5 && < 4.13
+               , ghc-prim >= 0.2 && < 0.6
+               , transformers >= 0.2 && < 0.6
+
+  Ghc-Options: -O2
+
+  Include-Dirs: cbits
+  Install-Includes: primitive-memops.h
+  includes: primitive-memops.h
+  c-sources: cbits/primitive-memops.c
+  if !os(solaris)
+      cc-options: -ftree-vectorize
+  if arch(i386) || arch(x86_64)
+      cc-options: -msse2
+
+source-repository head
+  type:     git
+  location: https://github.com/haskell/primitive


### PR DESCRIPTION
The most recent versions of `cassava` and `primitive` on Hackage actually do support GHC HEAD, but only because of revisions. Due to #65, `head.hackage` does not take these revisions into account and falls back on the original `.cabal` files with out-of-date bounds on `base` (for `primitive`) and `containers` (for `cassva`). As a workaround, this puts the most recent `.cabal` files (including revisions) for `cassava`/`primitive` into `head.hackage`.