### PR TITLE
hs-generate-overrides:  fix aeson

### DIFF
--- a/scripts/generate-nix-overrides.hs
+++ b/scripts/generate-nix-overrides.hs
@@ -1,7 +1,10 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i runghc -p "haskellPackages.ghcWithPackages (ps: [])"
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
 
 import Data.List
 import Distribution.Package
@@ -19,7 +22,8 @@ groupPatches assocs = Map.toAscList $ Map.fromListWith (++) [(k, [v]) | (k, v) <
 generateOverrides :: FilePath -> FilePath -> IO String
 generateOverrides prefix patchDir = do
   patches <- listDirectory patchDir
-  override_groups <- groupPatches <$> mapM (generateOverride prefix patchDir) patches
+  override_groups <- groupPatches <$> mapM (generateOverride prefix patchDir)
+                                           (groupPatches [ (dropExtension pf, decidePatchType pf) | pf <- patches ])
   let overrides = map mkOverride override_groups
   return $ intercalate "\n" overrides
 
@@ -39,30 +43,38 @@ mkOverride (display -> pName, patches) =
                         ,  quotes (intercalate "." (map show version))
                         ," then (", patch, ")"]
 
+override :: FilePath -> FilePath -> FilePath -> String -> PatchType -> String
+override prefix patchDir extlessPath nixexpr ptype =
+  unwords ["(", patchFunction ptype, nixexpr, prefix </> patchDir </> addExtension extlessPath (patchTypeExt ptype), ")"]
 
-generateOverride :: FilePath -> FilePath -> FilePath -> IO (PackageName, ([Int], String))
-generateOverride prefix patchDir patch = do
-  let ftype = decidePatchType patch
-      pid' :: Maybe PackageId  = simpleParse (takeBaseName patch)
-  pid <- maybe (fail ("invalid patch file name: " ++ show patch)) return pid'
+generateOverride :: FilePath -> FilePath -> (FilePath, [PatchType]) -> IO (PackageName, ([Int], String))
+generateOverride prefix patchDir (patchExtless, patchTypes) = do
+  let pid' :: Maybe PackageId  = simpleParse (takeFileName patchExtless)
+  pid <- maybe (fail ("invalid patch file name: " ++ show patchExtless)) return pid'
   let pname = display (packageName pid)
       version = versionNumbers (packageVersion pid)
-  return $ (packageName pid, (version,
-    unwords [ "dontRevise(", patchFunction ftype , "super."++pname, prefix </> patchDir </> patch, ")"]))
-
+  return . (packageName pid,) . (version,) $ 
+    "dontRevise "
+    ++ foldl' (override prefix patchDir patchExtless) ("super."++pname) patchTypes
 
 patchFunction :: PatchType -> String
-patchFunction CabalPatch = "setCabalFile"
-patchFunction NormalPatch = "haskell.lib.appendPatch"
+patchFunction = \case
+  CabalPatch  -> "setCabalFile"
+  NormalPatch -> "haskell.lib.appendPatch"
 
+patchTypeExt :: PatchType -> String
+patchTypeExt = \case
+  CabalPatch  -> ".cabal"
+  NormalPatch -> ".patch"
 
 decidePatchType :: FilePath -> PatchType
 decidePatchType patch =
   case takeExtension patch of
     ".cabal" -> CabalPatch
-    _ -> NormalPatch
+    ".patch" -> NormalPatch
+    _ -> error $ "Unexpected patch extension: " ++ patch
 
-data PatchType = CabalPatch | NormalPatch
+data PatchType = CabalPatch | NormalPatch deriving Eq
 
 main :: IO ()
 main = do

--- a/scripts/generate-nix-overrides.hs
+++ b/scripts/generate-nix-overrides.hs
@@ -42,12 +42,27 @@ mkOverride (display -> pName, patches) =
 
 generateOverride :: FilePath -> FilePath -> FilePath -> IO (PackageName, ([Int], String))
 generateOverride prefix patchDir patch = do
-  let pid' :: Maybe PackageId  = simpleParse (takeBaseName patch)
+  let ftype = decidePatchType patch
+      pid' :: Maybe PackageId  = simpleParse (takeBaseName patch)
   pid <- maybe (fail ("invalid patch file name: " ++ show patch)) return pid'
   let pname = display (packageName pid)
       version = versionNumbers (packageVersion pid)
   return $ (packageName pid, (version,
-    unwords [ "dontRevise(", "haskell.lib.appendPatch", "super."++pname, prefix </> patchDir </> patch, ")"]))
+    unwords [ "dontRevise(", patchFunction ftype , "super."++pname, prefix </> patchDir </> patch, ")"]))
+
+
+patchFunction :: PatchType -> String
+patchFunction CabalPatch = "setCabalFile"
+patchFunction NormalPatch = "haskell.lib.appendPatch"
+
+
+decidePatchType :: FilePath -> PatchType
+decidePatchType patch =
+  case takeExtension patch of
+    ".cabal" -> CabalPatch
+    _ -> NormalPatch
+
+data PatchType = CabalPatch | NormalPatch
 
 main :: IO ()
 main = do
@@ -60,6 +75,7 @@ main = do
   overrides <- generateOverrides prefix patchDir
   putStrLn "{haskell}:"
   putStrLn "let dontRevise = pkg: haskell.lib.overrideCabal pkg (old: { editedCabalFile = null; }); in"
+  putStrLn "let setCabalFile = pkg: file: haskell.lib.overrideCabal pkg (old: { postPatch = ''cp ${file} ${old.pname}.cabal''; }); in"
   putStrLn "self: super: {\n"
   putStrLn overrides
   putStrLn "}"

--- a/scripts/overrides.nix
+++ b/scripts/overrides.nix
@@ -4,18 +4,10 @@
              # it can either be a local directory or fetched from the web
 }:
 let
-  ghc = (haskell.packages.ghc822.override (oldArgs: {
-          overrides = self: super:
-            let parent = (oldArgs.overrides or (_: _: {})) self super;
-            in
-            parent // (with haskell.lib; with self; {
-              aeson = overrideCabal super.aeson (drv:
-                { libraryHaskellDepends = drv.libraryHaskellDepends ++ [contravariant];
-                });
-            });
-        })).ghcWithPackages (ps: with ps;
-          [ ps.hopenssl ps.distribution-nixpkgs
-          ]);
+  hpkgs = haskell.packages.ghc822.extend (self: super:
+            { aeson = haskell.lib.addBuildDepends super.aeson [self.contravariant]; });
+  ghc   = hpkgs.ghcWithPackages (ps: with ps;
+            [ hopenssl distribution-nixpkgs ]);
 in
 
 stdenv.mkDerivation {

--- a/scripts/overrides.nix
+++ b/scripts/overrides.nix
@@ -4,9 +4,18 @@
              # it can either be a local directory or fetched from the web
 }:
 let
-  ghc = haskell.packages.ghc822.ghcWithPackages (ps: with ps;
-        [ ps.hopenssl ps.distribution-nixpkgs
-        ]);
+  ghc = (haskell.packages.ghc822.override (oldArgs: {
+          overrides = self: super:
+            let parent = (oldArgs.overrides or (_: _: {})) self super;
+            in
+            parent // (with haskell.lib; with self; {
+              aeson = overrideCabal super.aeson (drv:
+                { libraryHaskellDepends = drv.libraryHaskellDepends ++ [contravariant];
+                });
+            });
+        })).ghcWithPackages (ps: with ps;
+          [ ps.hopenssl ps.distribution-nixpkgs
+          ]);
 in
 
 stdenv.mkDerivation {


### PR DESCRIPTION
..which is missing `contravariant` in Nixpkgs `master`.

Described in https://github.com/hvr/head.hackage/issues/94