### PR TITLE
Add data-dword-0.3.1.2 patch

### DIFF
--- a/patches/data-dword-0.3.1.2.patch
+++ b/patches/data-dword-0.3.1.2.patch
@@ -1,0 +1,123 @@
+diff --git a/src/Data/DoubleWord/TH.hs b/src/Data/DoubleWord/TH.hs
+index 1b4dc07..f4a3fe2 100644
+--- a/src/Data/DoubleWord/TH.hs
++++ b/src/Data/DoubleWord/TH.hs
+@@ -25,6 +25,9 @@ import Control.Applicative ((<$>), (<*>))
+ import Language.Haskell.TH hiding (unpacked, match)
+ import Data.BinaryWord (BinaryWord(..))
+ import Data.DoubleWord.Base
++#if MIN_VERSION_template_haskell(2,15,0)
++import Data.List (foldl')
++#endif
+ 
+ -- | Declare signed and unsigned binary word types built from
+ --   the specified low and high halves. The high halves /must/ have
+@@ -1378,8 +1381,12 @@ mkDoubleWord' signed tp cn otp ocn hiS hiT loS loT ad = (<$> mkRules) $ (++) $
+     hi'  = mkName "hi'"
+     lo'  = mkName "lo'"
+     tpT  = ConT tp
++
++    tySynInst :: Name -> [Type] -> Type -> Dec
+     tySynInst n ps t =
+-#if MIN_VERSION_template_haskell(2,9,0)
++#if MIN_VERSION_template_haskell(2,15,0)
++      TySynInstD (TySynEqn Nothing (foldl' AppT (ConT n) ps) t)
++#elif MIN_VERSION_template_haskell(2,9,0)
+       TySynInstD n (TySynEqn ps t)
+ #else
+       TySynInstD n ps t
+@@ -1448,11 +1455,11 @@ mkDoubleWord' signed tp cn otp ocn hiS hiT loS loT ad = (<$> mkRules) $ (++) $
+ #endif
+     singE e = appC '(:) [e, ConE '[]]
+     mkRules = do
+-      let idRule = RuleP ("fromIntegral/" ++ show tp ++ "->" ++ show tp) []
++      let idRule = RuleP ("fromIntegral/" ++ show tp ++ "->" ++ show tp) Nothing []
+                          (VarE 'fromIntegral)
+                          (SigE (VarE 'id) (AppT (AppT ArrowT tpT) tpT))
+                          AllPhases
+-          signRule = RuleP ("fromIntegral/" ++ show tp ++ "->" ++ show otp) []
++          signRule = RuleP ("fromIntegral/" ++ show tp ++ "->" ++ show otp) Nothing []
+                            (VarE 'fromIntegral)
+                            (SigE (VarE (if signed then 'unsignedWord
+                                                   else 'signedWord))
+@@ -1464,11 +1471,13 @@ mkDoubleWord' signed tp cn otp ocn hiS hiT loS loT ad = (<$> mkRules) $ (++) $
+                (VarE 'signExtendLo)
+     mkRules' rules t narrowE extE signExtE = do
+       let narrowRule = RuleP ("fromIntegral/" ++ show tp ++ "->" ++ showT t)
++                             Nothing
+                              []
+                              (VarE 'fromIntegral)
+                              (SigE narrowE (AppT (AppT ArrowT tpT) t))
+                              AllPhases
+           extRule = RuleP ("fromIntegral/" ++ showT t ++ "->" ++ show tp)
++                          Nothing
+                           []
+                           (VarE 'fromIntegral)
+                           (SigE extE (AppT (AppT ArrowT t) tpT))
+@@ -1476,18 +1485,22 @@ mkDoubleWord' signed tp cn otp ocn hiS hiT loS loT ad = (<$> mkRules) $ (++) $
+       signedRules ← do
+         insts ← reifyInstances ''SignedWord [t]
+         case insts of
+-#if MIN_VERSION_template_haskell(2,9,0)
++#if MIN_VERSION_template_haskell(2,15,0)
++          [TySynInstD (TySynEqn _ _ signT)] -> return $
++#elif MIN_VERSION_template_haskell(2,9,0)
+           [TySynInstD _ (TySynEqn _ signT)] → return $
+ #else
+           [TySynInstD _ _ signT] → return $
+ #endif
+             [ RuleP ("fromIntegral/" ++ show tp ++ "->" ++ showT signT)
++                    Nothing
+                     []
+                     (VarE 'fromIntegral)
+                     (SigE (AppE (appVN '(.) ['signedWord]) narrowE)
+                           (AppT (AppT ArrowT tpT) signT))
+                     AllPhases
+             , RuleP ("fromIntegral/" ++ showT signT ++ "->" ++ show tp)
++                    Nothing
+                     []
+                     (VarE 'fromIntegral)
+                     (SigE signExtE (AppT (AppT ArrowT signT) tpT))
+@@ -1501,6 +1514,7 @@ mkDoubleWord' signed tp cn otp ocn hiS hiT loS loT ad = (<$> mkRules) $ (++) $
+                     sSmallT = ConT sSmallName in
+                 [ RuleP ("fromIntegral/" ++
+                          show tp ++ "->" ++ show uSmallName)
++                        Nothing
+                         []
+                         (VarE 'fromIntegral)
+                         (SigE (appV '(.) [VarE 'fromIntegral, narrowE])
+@@ -1508,6 +1522,7 @@ mkDoubleWord' signed tp cn otp ocn hiS hiT loS loT ad = (<$> mkRules) $ (++) $
+                         AllPhases
+                 , RuleP ("fromIntegral/" ++
+                          show uSmallName ++ "->" ++ show tp)
++                        Nothing
+                         []
+                         (VarE 'fromIntegral)
+                         (SigE (appV '(.) [extE, VarE 'fromIntegral])
+@@ -1515,6 +1530,7 @@ mkDoubleWord' signed tp cn otp ocn hiS hiT loS loT ad = (<$> mkRules) $ (++) $
+                         AllPhases
+                 , RuleP ("fromIntegral/" ++
+                          show tp ++ "->" ++ show sSmallName)
++                        Nothing
+                         []
+                         (VarE 'fromIntegral)
+                         (SigE (appV '(.) [VarE 'fromIntegral, narrowE])
+@@ -1522,6 +1538,7 @@ mkDoubleWord' signed tp cn otp ocn hiS hiT loS loT ad = (<$> mkRules) $ (++) $
+                         AllPhases
+                 , RuleP ("fromIntegral/" ++
+                          show sSmallName ++ "->" ++ show tp)
++                        Nothing
+                         []
+                         (VarE 'fromIntegral)
+                         (SigE (appV '(.) [signExtE, VarE 'fromIntegral])
+@@ -1532,7 +1549,9 @@ mkDoubleWord' signed tp cn otp ocn hiS hiT loS loT ad = (<$> mkRules) $ (++) $
+         _ → do
+           insts ← reifyInstances ''LoWord [t]
+           case insts of
+-#if MIN_VERSION_template_haskell(2,9,0)
++#if MIN_VERSION_template_haskell(2,15,0)
++            [TySynInstD (TySynEqn _ _ t')] ->
++#elif MIN_VERSION_template_haskell(2,9,0)
+             [TySynInstD _ (TySynEqn _ t')] →
+ #else
+             [TySynInstD _ _ t'] →


### PR DESCRIPTION
When I apply this patch I can build `data-dword` dependencies in packages that build with head.hackage overlay (tested by adding `data-dword` with this patch applied as a package in `cabal.project` that uses head.hackage).

I have no idea if I'm doing this right so please check my work.