### PR TITLE
Add copy-and-pastable head.hackage stanza in README for easy access

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ The main operations provided are
 
 - `head.hackage.sh dump-repo`: print `repository` stanza to stdout
 
+If you wish to enable `head.hackage` in an existing `cabal.project(.local)` file, you can copy and past the following lines into it:
+
+```
+with-compiler: <path-to-ghc-head>
+
+repository head.hackage
+   url: http://head.hackage.haskell.org/
+   secure: True
+   root-keys: 07c59cb65787dedfaef5bd5f987ceb5f7e5ebf88b904bbd4c5cbdeb2ff71b740
+              2e8555dde16ebd8df076f1a8ef13b8f14c66bad8eafefd7d9e37d0ed711821fb
+              8f79fd2389ab2967354407ec852cbe73f2e8635793ac446d09461ffb99527f6e
+   key-threshold: 3
+```
 
 ### As an add-on local repository
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The main operations provided are
 
 - `head.hackage.sh dump-repo`: print `repository` stanza to stdout
 
-If you wish to enable `head.hackage` in an existing `cabal.project(.local)` file, you can copy and past the following lines into it:
+If you wish to enable `head.hackage` in an existing `cabal.project(.local)` file, you can copy and paste the following lines into it:
 
 ```
 with-compiler: <path-to-ghc-head>


### PR DESCRIPTION
I often find myself enabling `head.hackage` in a repo that already has a `cabal.project` file. Currently, the only way to do this is to move the original `cabal.project` somewhere else, create a new `cabal.project` file with `head.hackage.sh init`, then copy back the relevant information from the renamed `cabal.project` file. This is a rather laborious process, and it would save me time to just copy-and-pase the `repository head.hackage` stanza into the existing `cabal.project` file.

Since I can never remember the `root-keys` that go along with this stanza, this PR adds the full thing to the `README` for easy access.