### PR TITLE
Adapt to GHC proposal 24

### DIFF
--- a/patches/constraints-0.10.1.patch
+++ b/patches/constraints-0.10.1.patch
@@ -1,0 +1,26 @@
+commit e03f3dfcffdda101ff48b508a80cc5d99cba89e2
+Author: Ryan Scott <ryan.gl.scott@gmail.com>
+Date:   Thu Feb 21 06:44:43 2019 -0500
+
+    Fix the build with GHC 8.9
+
+diff --git a/src/Data/Constraint/Forall.hs b/src/Data/Constraint/Forall.hs
+index 3932f29..185fc95 100644
+--- a/src/Data/Constraint/Forall.hs
++++ b/src/Data/Constraint/Forall.hs
+@@ -142,8 +142,14 @@ instance Forall (R p t a) => Q p t a
+ class Forall (Q p t) => ForallT (p :: k4 -> Constraint) (t :: (k1 -> k2) -> k3 -> k4)
+ instance Forall (Q p t) => ForallT p t
+ 
++#if __GLASGOW_HASKELL__ >= 809
++# define KVS(kvs) kvs
++#else
++# define KVS(kvs)
++#endif
++
+ -- | Instantiate a quantified @'ForallT' p t@ constraint at types @f@ and @a@.
+-instT :: forall (p :: k4 -> Constraint) (t :: (k1 -> k2) -> k3 -> k4) (f :: k1 -> k2) (a :: k3). ForallT p t :- p (t f a)
++instT :: forall KVS(k4 k1 k2 k3) (p :: k4 -> Constraint) (t :: (k1 -> k2) -> k3 -> k4) (f :: k1 -> k2) (a :: k3). ForallT p t :- p (t f a)
+ instT = Sub $
+   case inst :: Forall (Q p t) :- Q p t f of { Sub Dict ->
+   case inst :: Forall (R p t f) :- R p t f a of

--- a/patches/lens-4.17.patch
+++ b/patches/lens-4.17.patch
@@ -1,6 +1,57 @@
-commit 7d5a0d5436dbdf9d545329ae57dc4d750c1934d1
+commit c047d22db63f5d7ed32bd0252c59c6615d6d6a63
 Author: Ryan Scott <ryan.gl.scott@gmail.com>
-Date:   Sat Dec 29 21:30:56 2018 -0500
+Date:   Thu Feb 21 07:06:00 2019 -0500
+
+    Allow building with GHC 8.9
+
+diff --git a/src/Control/Lens/Equality.hs b/src/Control/Lens/Equality.hs
+index c4f1f9f1..c186b3ed 100644
+--- a/src/Control/Lens/Equality.hs
++++ b/src/Control/Lens/Equality.hs
+@@ -73,7 +73,13 @@ substEq l = case runEq l of
+ 
+ -- | We can use 'Equality' to do substitution into anything.
+ #if __GLASGOW_HASKELL__ >= 706
+-mapEq :: forall (s :: k1) (t :: k2) (a :: k1) (b :: k2) (f :: k1 -> *) . AnEquality s t a b -> f s -> f a
++# if __GLASGOW_HASKELL__ >= 809
++#  define KVS(kvs) kvs
++# else
++#  define KVS(kvs)
++# endif
++
++mapEq :: forall KVS(k1 k2) (s :: k1) (t :: k2) (a :: k1) (b :: k2) (f :: k1 -> *) . AnEquality s t a b -> f s -> f a
+ #else
+ mapEq :: AnEquality s t a b -> f s -> f a
+ #endif
+diff --git a/tests/properties.hs b/tests/properties.hs
+index 90e74f35..4bd53a2a 100644
+--- a/tests/properties.hs
++++ b/tests/properties.hs
+@@ -123,12 +123,18 @@ sampleExtremePoly f foo = f foo
+ samplePolyEquality :: Equality Monad Identity Monad Identity
+ samplePolyEquality f = f
+ 
+-lessSimplePoly :: forall (s :: k1) (t :: k2) (a :: k1) (b :: k2) .
++# if __GLASGOW_HASKELL__ >= 809
++#  define KVS(kvs) kvs
++# else
++#  define KVS(kvs)
++# endif
++
++lessSimplePoly :: forall KVS(k1 k2) (s :: k1) (t :: k2) (a :: k1) (b :: k2) .
+                   Equality a b a b
+ lessSimplePoly f = f
+ 
+ equalityAnEqualityPoly ::
+-       forall (s :: k1) (t :: k2) (a :: k1) (b :: k2) .
++       forall KVS(k1 k2) (s :: k1) (t :: k2) (a :: k1) (b :: k2) .
+        Equality s t a b -> AnEquality s t a b
+ equalityAnEqualityPoly f = f
+ #else
+
+commit 9757e2808a7409651b7dfb274041ef69a6fac2ed
+Author: Ryan Scott <ryan.gl.scott@gmail.com>
+Date:   Thu Feb 21 06:57:55 2019 -0500
 
     Allow building with template-haskell-2.15.0.0
 

--- a/patches/singleton-bool-0.1.4.cabal
+++ b/patches/singleton-bool-0.1.4.cabal
@@ -1,0 +1,47 @@
+cabal-version:  >= 1.10
+name:           singleton-bool
+version:        0.1.4
+x-revision:     1
+
+synopsis:       Type level booleans
+description:    Type level booleans.
+                .
+                @singletons@ package provides similar functionality,
+                but it has tight dependency constraints.
+category:       Web
+homepage:       https://github.com/phadej/singleton-bool#readme
+bug-reports:    https://github.com/phadej/singleton-bool/issues
+author:         Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+tested-with:
+  GHC==7.6.3,
+  GHC==7.8.4,
+  GHC==7.10.3,
+  GHC==8.0.2,
+  GHC==8.2.2,
+  GHC==8.4.3,
+  GHC==8.6.1
+
+extra-source-files:
+  CHANGELOG.md
+  README.md
+
+source-repository head
+  type: git
+  location: https://github.com/phadej/singleton-bool
+
+library
+  hs-source-dirs:
+    src
+  ghc-options: -Wall
+  build-depends:
+    base        >=4.6 && <4.13
+  exposed-modules:
+    Data.Singletons.Bool
+  default-language: Haskell2010
+
+  if !impl(ghc >= 7.8)
+    build-depends: tagged >= 0.8.5 && <0.9

--- a/patches/singleton-bool-0.1.4.patch
+++ b/patches/singleton-bool-0.1.4.patch
@@ -1,0 +1,28 @@
+commit daf73dfbc836348088d2ad88ecf89bdede000982
+Author: Ryan Scott <ryan.gl.scott@gmail.com>
+Date:   Thu Feb 21 06:51:44 2019 -0500
+
+    Allow building with GHC 8.9
+
+diff --git a/src/Data/Singletons/Bool.hs b/src/Data/Singletons/Bool.hs
+index bcbfe18..3d4d6d5 100644
+--- a/src/Data/Singletons/Bool.hs
++++ b/src/Data/Singletons/Bool.hs
+@@ -113,10 +113,16 @@ eqCast = unsafeCoerce
+ trivialRefl :: () :~: ()
+ trivialRefl = Refl
+ 
++# if __GLASGOW_HASKELL__ >= 809
++#  define KVS(kvs) kvs
++# else
++#  define KVS(kvs)
++# endif
++
+ -- | Useful combination of 'sbool' and 'eqToRefl'
+ --
+ -- @since 0.1.2.0
+-sboolEqRefl :: forall (a :: k) (b :: k). SBoolI (a == b) => Maybe (a :~: b)
++sboolEqRefl :: forall KVS(k) (a :: k) (b :: k). SBoolI (a == b) => Maybe (a :~: b)
+ sboolEqRefl = case sbool :: SBool (a == b) of
+     STrue  -> Just eqToRefl
+     SFalse -> Nothing


### PR DESCRIPTION
GHC [proposal 24](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0024-no-kind-vars.rst) (Treat kind variables and type variables identically in `forall`) breaks a handful of libraries that implicitly quantify kind variables in a top-level `forall`, so these patches work around this.