### PR TITLE
Patch th-orphans to work around https://github.com/mgsloan/th-orphans/issues/27

### DIFF
--- a/patches/th-orphans-0.13.6.patch
+++ b/patches/th-orphans-0.13.6.patch
@@ -1,0 +1,22 @@
+commit a6dc0285a37ca46c4d4771e7955491c37777b430
+Author: Ryan Scott <ryan.gl.scott@gmail.com>
+Date:   Sat Mar 9 15:20:22 2019 -0500
+
+    Work around https://github.com/mgsloan/th-orphans/issues/27
+
+diff --git a/src/Language/Haskell/TH/Instances.hs b/src/Language/Haskell/TH/Instances.hs
+index bd4d85b..4b2b522 100644
+--- a/src/Language/Haskell/TH/Instances.hs
++++ b/src/Language/Haskell/TH/Instances.hs
+@@ -517,5 +517,11 @@ deriving instance Typeable Ppr
+ deriving instance Typeable Quasi
+ #endif
+ 
++#if __GLASGOW_HASKELL__ >= 809
++-- Work around https://github.com/mgsloan/th-orphans/issues/27
++instance Lift Bytes where
++  lift (Bytes _fp off sz) = [| Bytes (error "Cannot lift ForeignPtr") off sz |]
++#endif
++
+ $(reifyManyWithoutInstances ''Lift [''Info, ''Loc] (const True) >>=
+   deriveLiftMany)


### PR DESCRIPTION
`th-orphans` currently does not build on GHC HEAD due to mgsloan/th-orphans#27. It's not entirely clear how the library should be patched, but adding a partial `Lift Bytes` instance does the job for now.