### PR TITLE
Patch some packages to work with Cabal-2.5, template-haskell-2.15

### DIFF
--- a/patches/hpack-0.31.2.patch
+++ b/patches/hpack-0.31.2.patch
@@ -1,0 +1,97 @@
+commit 1b8d1bc872df52f427b1a1b0ec494bc9c4b4c333
+Author: Ryan Scott <ryan.gl.scott@gmail.com>
+Date:   Sat Mar 16 11:33:08 2019 -0400
+
+    Adapt to GHC 8.8
+
+diff --git a/src/Hpack/Config.hs b/src/Hpack/Config.hs
+index 5710b49..aba76b9 100644
+--- a/src/Hpack/Config.hs
++++ b/src/Hpack/Config.hs
+@@ -5,6 +5,7 @@
+ {-# LANGUAGE DeriveAnyClass #-}
+ {-# LANGUAGE FlexibleInstances #-}
+ {-# LANGUAGE LambdaCase #-}
++{-# LANGUAGE LiberalTypeSynonyms #-}
+ {-# LANGUAGE OverloadedStrings #-}
+ {-# LANGUAGE RecordWildCards #-}
+ {-# LANGUAGE CPP #-}
+diff --git a/src/Hpack/License.hs b/src/Hpack/License.hs
+index d3a69cb..4786a3b 100644
+--- a/src/Hpack/License.hs
++++ b/src/Hpack/License.hs
+@@ -1,3 +1,4 @@
++{-# LANGUAGE CPP #-}
+ {-# LANGUAGE DeriveFunctor #-}
+ {-# LANGUAGE ViewPatterns #-}
+ {-# LANGUAGE LambdaCase #-}
+@@ -9,7 +10,11 @@ import           Distribution.Pretty (prettyShow)
+ import           Distribution.Version (mkVersion)
+ import qualified Distribution.License as Cabal
+ import qualified Distribution.SPDX.License as SPDX
++#if MIN_VERSION_Cabal(2,5,0)
++import           Distribution.Parsec (eitherParsec)
++#else
+ import           Distribution.Parsec.Class (eitherParsec)
++#endif
+ 
+ import qualified Data.License.Infer as Infer
+ 
+diff --git a/src/Hpack/Syntax/DependencyVersion.hs b/src/Hpack/Syntax/DependencyVersion.hs
+index cb8abcf..84a7b05 100644
+--- a/src/Hpack/Syntax/DependencyVersion.hs
++++ b/src/Hpack/Syntax/DependencyVersion.hs
+@@ -1,3 +1,4 @@
++{-# LANGUAGE CPP #-}
+ {-# LANGUAGE OverloadedStrings #-}
+ {-# LANGUAGE LambdaCase #-}
+ module Hpack.Syntax.DependencyVersion (
+@@ -34,7 +35,12 @@ import           Text.PrettyPrint (renderStyle, Style(..), Mode(..))
+ import           Distribution.Version (VersionRangeF(..))
+ import qualified Distribution.Text as D
+ import qualified Distribution.Version as D
++#if MIN_VERSION_Cabal(2,5,0)
++import qualified Distribution.Parsec as D
++import qualified Distribution.Pretty as D
++#else
+ import qualified Distribution.Parsec.Class as D
++#endif
+ 
+ import           Data.Aeson.Config.FromValue
+ 
+@@ -147,7 +153,13 @@ cabalParse subject s = case D.eitherParsec s of
+ versionConstraintFromCabal :: D.VersionRange -> VersionConstraint
+ versionConstraintFromCabal range
+   | D.isAnyVersion range = AnyVersion
+-  | otherwise = VersionRange . renderStyle style . D.disp $ toPreCabal2VersionRange range
++  | otherwise = VersionRange . renderStyle style
++#if MIN_VERSION_Cabal(2,5,0)
++                             . D.pretty
++#else
++                             . D.disp
++#endif
++                             $ toPreCabal2VersionRange range
+   where
+     style = Style OneLineMode 0 0
+ 
+diff --git a/test/Hpack/LicenseSpec.hs b/test/Hpack/LicenseSpec.hs
+index ce6cb1a..ffb7d25 100644
+--- a/test/Hpack/LicenseSpec.hs
++++ b/test/Hpack/LicenseSpec.hs
+@@ -1,3 +1,4 @@
++{-# LANGUAGE CPP #-}
+ {-# LANGUAGE QuasiQuotes #-}
+ module Hpack.LicenseSpec (spec) where
+ 
+@@ -6,7 +7,11 @@ import           Data.Maybe
+ import           Data.String.Interpolate
+ 
+ import           Distribution.Pretty (prettyShow)
++#if MIN_VERSION_Cabal(2,5,0)
++import           Distribution.Parsec (simpleParsec)
++#else
+ import           Distribution.Parsec.Class (simpleParsec)
++#endif
+ import qualified Distribution.License as Cabal
+ 
+ import           Hpack.License

--- a/patches/persistent-template-2.6.0.patch
+++ b/patches/persistent-template-2.6.0.patch
@@ -1,0 +1,72 @@
+diff -ru persistent-template-2.6.0.orig/Database/Persist/TH.hs persistent-template-2.6.0/Database/Persist/TH.hs
+--- persistent-template-2.6.0.orig/Database/Persist/TH.hs	2019-01-27 08:37:47.000000000 -0500
++++ persistent-template-2.6.0/Database/Persist/TH.hs	2019-03-16 11:41:13.023259763 -0400
+@@ -518,8 +518,14 @@
+ 
+ uniqueTypeDec :: MkPersistSettings -> EntityDef -> Dec
+ uniqueTypeDec mps t =
+-    DataInstD [] ''Unique
++    DataInstD []
++#if MIN_VERSION_template_haskell(2,15,0)
++        Nothing
++        (ConT ''Unique `AppT` genericDataType mps (entityHaskell t) backendT)
++#else
++        ''Unique
+         [genericDataType mps (entityHaskell t) backendT]
++#endif
+ #if MIN_VERSION_template_haskell(2,11,0)
+             Nothing
+ #endif
+@@ -785,7 +791,12 @@
+                         bi <- backendKeyI
+                         return (bi, allInstances)
+ 
+-#if MIN_VERSION_template_haskell(2,12,0)
++#if MIN_VERSION_template_haskell(2,15,0)
++    cxti <- mapM conT i
++    let kd = if useNewtype
++               then NewtypeInstD [] Nothing (ConT k `AppT` recordType) Nothing dec [DerivClause Nothing cxti]
++               else DataInstD    [] Nothing (ConT k `AppT` recordType) Nothing [dec] [DerivClause Nothing cxti]
++#elif MIN_VERSION_template_haskell(2,12,0)
+     cxti <- mapM conT i
+     let kd = if useNewtype
+                then NewtypeInstD [] k [recordType] Nothing dec [DerivClause Nothing cxti]
+@@ -1076,16 +1087,30 @@
+         , puk
+         , DataInstD
+             []
++#if MIN_VERSION_template_haskell(2,15,0)
++            Nothing
++            (ConT ''EntityField `AppT`
++             genDataType `AppT`
++             (VarT $ mkName "typ"))
++#else
+             ''EntityField
+             [ genDataType
+             , VarT $ mkName "typ"
+             ]
++#endif
+ #if MIN_VERSION_template_haskell(2,11,0)
+             Nothing
+ #endif
+             (map fst fields)
+             []
+         , FunD 'persistFieldDef (map snd fields)
++#if MIN_VERSION_template_haskell(2,15,0)
++        , TySynInstD
++            (TySynEqn
++               Nothing
++               (ConT ''PersistEntityBackend `AppT` genDataType)
++               (backendDataType mps))
++#else
+         , TySynInstD
+             ''PersistEntityBackend
+ #if MIN_VERSION_template_haskell(2,9,0)
+@@ -1096,6 +1121,7 @@
+             [genDataType]
+             (backendDataType mps)
+ #endif
++#endif
+         , FunD 'persistIdField [normalClause [] (ConE $ keyIdName t)]
+         , FunD 'fieldLens lensClauses
+         ]

--- a/patches/recursion-schemes-5.1.2.patch
+++ b/patches/recursion-schemes-5.1.2.patch
@@ -1,0 +1,21 @@
+commit 163fe274fb0eef35fd2a22f6601e09dfcda977c9
+Author: Ryan Scott <ryan.gl.scott@gmail.com>
+Date:   Sat Mar 16 11:20:05 2019 -0400
+
+    Adapt to template-haskell-2.15.0.0
+
+diff --git a/src/Data/Functor/Foldable/TH.hs b/src/Data/Functor/Foldable/TH.hs
+index 076f0ed..8041a86 100644
+--- a/src/Data/Functor/Foldable/TH.hs
++++ b/src/Data/Functor/Foldable/TH.hs
+@@ -194,7 +194,9 @@ makePrimForDI' rules isNewtype tyName vars cons = do
+ #endif
+ 
+     -- type instance Base
+-#if MIN_VERSION_template_haskell(2,9,0)
++#if MIN_VERSION_template_haskell(2,15,0)
++    let baseDec = TySynInstD (TySynEqn Nothing (ConT baseTypeName `AppT` s) $ conAppsT tyNameF vars')
++#elif MIN_VERSION_template_haskell(2,9,0)
+     let baseDec = TySynInstD baseTypeName (TySynEqn [s] $ conAppsT tyNameF vars')
+ #else
+     let baseDec = TySynInstD baseTypeName [s] $ conAppsT tyNameF vars'

--- a/patches/yesod-core-1.6.13.patch
+++ b/patches/yesod-core-1.6.13.patch
@@ -1,0 +1,15 @@
+diff -ru yesod-core-1.6.13.orig/src/Yesod/Routes/TH/RenderRoute.hs yesod-core-1.6.13/src/Yesod/Routes/TH/RenderRoute.hs
+--- yesod-core-1.6.13.orig/src/Yesod/Routes/TH/RenderRoute.hs	2019-03-17 05:12:08.000000000 -0400
++++ yesod-core-1.6.13/src/Yesod/Routes/TH/RenderRoute.hs	2019-03-17 09:04:44.369924530 -0400
+@@ -142,7 +142,11 @@
+     cls <- mkRenderRouteClauses ress
+     (cons, decs) <- mkRouteCons ress
+ #if MIN_VERSION_template_haskell(2,12,0)
++# if MIN_VERSION_template_haskell(2,15,0)
++    did <- DataInstD [] Nothing (ConT ''Route `AppT` typ) Nothing cons <$> fmap (pure . DerivClause Nothing) (mapM conT (clazzes False))
++# else
+     did <- DataInstD [] ''Route [typ] Nothing cons <$> fmap (pure . DerivClause Nothing) (mapM conT (clazzes False))
++# endif
+     let sds = fmap (\t -> StandaloneDerivD Nothing cxt $ ConT t `AppT` ( ConT ''Route `AppT` typ)) (clazzes True)
+ #else
+     did <- DataInstD [] ''Route [typ] Nothing cons <$> mapM conT (clazzes False)


### PR DESCRIPTION
`hpack` needs some CPP to work with `Cabal-2.5`, while `persistent-template`, `recursion-schemes`, and `yesod-core` needs some CPP to work with `template-haskell-2.15`.