### PR TITLE
Nix-based CI infrastructure for GitLab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist-newstyle
+packages
+cabal.project.local

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,88 @@
+# GHC/head.hackage CI support
+# ===========================
+#
+# This is the GitLab CI automation that drives GHC's head.hackage testing.
+# The goal is to be able to test GHC by building a (small) subset of Hackage.
+# Moreover, we want to be able to collect logs of failed builds as well as
+# performance metrics from builds that succeed.
+#
+# To accomplish this we use head.hackage's native Nix support and the
+# ghc-artefact-nix expression to make GHC binary distributions usable from
+# within Nix. These components are tied together by ./scripts/build-all.nix,
+# which contains the list of packages which we build as well as some simple
+# configuration to minimize the cost of the builds.
+#
+
+variables:
+  # Commit of ghc/ci-images repository from which to pull Docker images
+  DOCKER_REV: 6d19c3adc1f5c28c82aed8c5b1ac40931ac60f3f
+
+  # A default for testing
+  GHC_TARBALL: https://gitlab.haskell.org/ghc/ghc/-/jobs/33075/artifacts/raw/ghc.tar.xz
+
+  # Project ID of ghc/ghc
+  GHC_PROJECT_ID: "1"
+
+  # ACCESS_TOKEN provided via protected environment variable
+
+build:
+  tags:
+    - x86_64-linux
+    - head.hackage
+
+  image: nixos/nix
+
+  cache:
+    key: build-all
+    paths:
+      - store.nar
+
+  before_script:
+    - |
+      if [ -e store.nar ]; then
+        echo "Extracting cached Nix store..."
+        nix-store --import -vv < store.nar || echo "invalid cache"
+      else
+        echo "No cache found"
+      fi
+
+  script:
+    - |
+      if [ -n "$GHC_PIPELINE_ID" ]; then
+        job_name="validate-x86_64-linux-fedora27"
+        job_id=$(nix run -f scripts/build-all.nix find-job \
+          --arg bindistTarball $GHC_TARBALL \
+          -c find-job.sh $GHC_PROJECT_ID $GHC_PIPELINE_ID $job_name)
+        echo "Pulling ${job_name} binary distribution from Pipeline $GHC_PIPELINE_ID (job $job_id)..."
+        GHC_TARBALL="https://gitlab.haskell.org/ghc/ghc/-/jobs/$job_id/artifacts/raw/ghc-x86_64-fedora27-linux.tar.xz"
+      fi
+
+    - echo "Bindist tarball is $GHC_TARBALL"
+    - nix-build scripts/build-all.nix -j$CPUS
+        --no-build-output
+        -A buildDepends
+        --arg bindistTarball $GHC_TARBALL
+    - nix-store --export $(nix-store -qR --include-outputs $(nix-instantiate --quiet scripts/build-all.nix --arg bindistTarball $GHC_TARBALL -A buildDepends -A ghc)) > store.nar
+    - ret=0
+    - nix-build scripts/build-all.nix
+        -j$CPUS --no-build-output
+        -A testedPackages
+        --keep-going
+        --arg bindistTarball $GHC_TARBALL
+        || (echo "Build failed!"; ret=1)
+    - scripts/summarize.py || echo "summarize script failed"
+    - exit $ret
+
+  after_script:
+    - nix run -f '<nixpkgs>' gnutar -c tar -zcf logs.tar.gz logs
+      # The following throws a fontconfig error but it appears to be innocuous.
+    - nix run -f '<nixpkgs>' graphviz -c dot -O -T svg summary.dot
+    - ls -lh
+
+  artifacts:
+    when: always
+    paths:
+    - logs.tar.gz
+    - summary.json
+    - summary.dot
+    - summary.dot.svg

--- a/README.md
+++ b/README.md
@@ -140,6 +140,17 @@ build `head.hackage` packages:
 ```
 $ nix build -f ./. --arg ghc "(import ghc-from-source.nix {ghc-path=$GHC_TREE;})"
 ```
+### GitLab CI
+
+[GHC's GitLab instance](https://gitlab.haskell.org/ghc/head.hackage) uses
+GitLab CI and `nix` to build a subset of the head.hackage package set using GHC
+snapshots.
+
+To run a similar build locally simply download a binary distribution from a
+`x86_64-fedora27-linux` CI job and run:
+```
+$ nix build -f scripts/build-all.nix --arg bindistTarball ./ghc-x86_64-fedora27-linux.tar.xz testedPackages
+```
 
 ### Travis CI
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,13 @@ $ cp ${WhereThisGitHubRepoIsCloned}/patches/$PKGID.cabal ./*.cabal
 $ cd ..
 ```
 
-TODO: implement script
+Alternatively, you can use the handy `patch-tool` utility:
+
+```
+$ scripts/patch-tool unpack-patch patches/$PKGID.patch
+```
+This will extract the given package into the `packages/$PKGID` directory,
+initialize it as a git repository, and the patch.
 
 ### Adding a patch
 

--- a/default.nix
+++ b/default.nix
@@ -8,11 +8,11 @@
 #       nix build -f --arg ghc "(import build.nix {ghc-path=$GHC_TREE;})"
 #
 let
-  rev = "f2632f5c60f574d787fc5490efb3f43f9e6209b7";
+  rev = "1222e289b5014d17884a8b1c99f220c5e3df0b14";
   baseNixpkgs =
     builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
-    sha256 = "1c36p7w36i38gng3yp1nd5vz0p2dwrax5szjkvnmdxfklggs7knf";
+    sha256 = "1sa2m8kdak6y9183jgizg95swrv9ich05lsnli0bdc8r11wahl54";
   };
 in
 
@@ -83,8 +83,8 @@ let
               http-api-data = haskellPackages.callPackage ./http-api-data.nix {};
               tagged = self1.callHackage "tagged" "0.8.6" {};
 
-              jailbreak-cabal = self.haskell.packages.ghc802.jailbreak-cabal;
-              cabal2nix = self.haskell.packages.ghc843.cabal2nix;
+              jailbreak-cabal = self.haskell.packages.ghc864.jailbreak-cabal;
+              cabal2nix = self.haskell.packages.ghc864.cabal2nix;
             };
           };
       in baseHaskellPackages.extend overrides;

--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,9 @@ let
 in
 
 # ghc: path to a GHC source tree
-{ ghc ? import ./ghc-prerelease.nix }:
+{ ghc ? import ./ghc-prerelease.nix
+, haskellOverrides ? (self: super: self)
+}:
 
 let
   jailbreakOverrides = self: super: {
@@ -33,7 +35,10 @@ let
     haskellPackages =
       let patchesOverrides = self.callPackage patches {};
           patches = self.callPackage (import ./scripts/overrides.nix) { patches = ./patches; };
-          overrides = self.lib.composeExtensions patchesOverrides jailbreakOverrides;
+          overrides =
+            self.lib.composeExtensions
+              haskellOverrides
+              (self.lib.composeExtensions patchesOverrides jailbreakOverrides);
 
           baseHaskellPackages = self.callPackage "${baseNixpkgs}/pkgs/development/haskell-modules" {
             haskellLib = import "${baseNixpkgs}/pkgs/development/haskell-modules/lib.nix" {

--- a/patches/aeson-1.4.2.0.cabal
+++ b/patches/aeson-1.4.2.0.cabal
@@ -107,9 +107,9 @@ library
     containers       >= 0.4.2.1 && < 0.7,
     deepseq          >= 1.3.0.0 && < 1.5,
     ghc-prim         >= 0.2     && < 0.6,
-    template-haskell >= 2.7.0.0 && < 2.15,
+    template-haskell >= 2.7.0.0 && < 2.16,
     text             >= 1.2.3.0 && < 1.3,
-    time             >= 1.4     && < 1.9
+    time             >= 1.4     && < 1.10
 
   -- Compat
   build-depends:

--- a/patches/exceptions-0.10.0.cabal
+++ b/patches/exceptions-0.10.0.cabal
@@ -36,7 +36,7 @@ library
   build-depends:
     base                       >= 4.3      && < 5,
     stm                        >= 2.2      && < 3,
-    template-haskell           >= 2.2      && < 2.15,
+    template-haskell           >= 2.2      && < 2.16,
     transformers               >= 0.2      && < 0.6,
     transformers-compat        >= 0.3      && < 0.7,
     mtl                        >= 2.0      && < 2.3

--- a/patches/primitive-0.6.4.0.cabal
+++ b/patches/primitive-0.6.4.0.cabal
@@ -54,7 +54,7 @@ Library
         Data.Primitive.Internal.Compat
         Data.Primitive.Internal.Operations
 
-  Build-Depends: base >= 4.5 && < 4.13
+  Build-Depends: base >= 4.5 && < 4.14
                , ghc-prim >= 0.2 && < 0.6
                , transformers >= 0.2 && < 0.6
 

--- a/patches/singleton-bool-0.1.4.cabal
+++ b/patches/singleton-bool-0.1.4.cabal
@@ -38,7 +38,7 @@ library
     src
   ghc-options: -Wall
   build-depends:
-    base        >=4.6 && <4.13
+    base        >=4.6 && <4.14
   exposed-modules:
     Data.Singletons.Bool
   default-language: Haskell2010

--- a/patches/singleton-bool-0.1.4.patch
+++ b/patches/singleton-bool-0.1.4.patch
@@ -1,9 +1,3 @@
-commit daf73dfbc836348088d2ad88ecf89bdede000982
-Author: Ryan Scott <ryan.gl.scott@gmail.com>
-Date:   Thu Feb 21 06:51:44 2019 -0500
-
-    Allow building with GHC 8.9
-
 diff --git a/src/Data/Singletons/Bool.hs b/src/Data/Singletons/Bool.hs
 index bcbfe18..3d4d6d5 100644
 --- a/src/Data/Singletons/Bool.hs

--- a/patches/tagged-0.8.6.patch
+++ b/patches/tagged-0.8.6.patch
@@ -1,0 +1,13 @@
+diff --git a/tagged.cabal b/tagged.cabal
+index 5fc399b..c19da25 100644
+--- a/tagged.cabal
++++ b/tagged.cabal
+@@ -67,7 +67,7 @@ library
+ 
+   if impl(ghc>=7.6)
+     exposed-modules: Data.Proxy.TH
+-    build-depends: template-haskell >= 2.8 && < 2.15
++    build-depends: template-haskell >= 2.8 && < 2.16
+ 
+   if flag(deepseq)
+     build-depends: deepseq >= 1.1 && < 1.5

--- a/patches/th-lift-0.7.11.patch
+++ b/patches/th-lift-0.7.11.patch
@@ -1,0 +1,13 @@
+diff --git a/th-lift.cabal b/th-lift.cabal
+index bfd13eb..7dd7081 100644
+--- a/th-lift.cabal
++++ b/th-lift.cabal
+@@ -32,7 +32,7 @@ Library
+     Build-Depends: packedstring == 0.1.*,
+                    template-haskell >= 2.2 && < 2.4
+   else
+-    Build-Depends: template-haskell >= 2.4 && < 2.15
++    Build-Depends: template-haskell >= 2.4 && < 2.16
+ 
+ Test-Suite test
+   Type:             exitcode-stdio-1.0

--- a/scripts/build-all.nix
+++ b/scripts/build-all.nix
@@ -1,0 +1,126 @@
+# GHC/head.hackage CI support
+#
+# See .gitlab-ci.yml in the root of this repository.
+
+# Expects to be run on x86_64.
+# bindistTarball should be a fedora27 tarball.
+{ bindistTarball }:
+
+let
+  # GHC from the given bindist.
+  ghc =
+    let
+      commit = "633c6d7553d0f2c91245bcf47ae539cfdb7aaa13";
+      src = fetchTarball {
+        url = "https://github.com/bgamari/ghc-artefact-nix/archive/${commit}.tar.gz";
+        sha256 = "0yl7dk8drb92ipgph1mxx8my4gy9py27m749zw6ah6np4gvdp9sx";
+      };
+    in nixpkgs.callPackage "${src}/artifact.nix" {} {
+      ncursesVersion = "6";
+      bindistTarball =
+        if builtins.typeOf bindistTarball == "path"
+        then bindistTarball
+        else builtins.fetchurl bindistTarball;
+    };
+
+  # Build configuration.
+  nixpkgs = import ../. {
+    ghc = self: ghc;
+    haskellOverrides = self: super: rec {
+      mkDerivation = drv: super.mkDerivation (drv // {
+        doHaddock = false;
+        enableLibraryProfiling = false;
+        enableExecutableProfiling = false;
+        hyperlinkSource = false;
+        configureFlags = (drv.configureFlags or []) ++ [
+          "--ghc-options=-ddump-timings"
+        ];
+      });
+    };
+  };
+
+  # Build dependencies worth caching.
+  buildDepends = with nixpkgs; [
+    buildPackages.haskellPackages.jailbreak-cabal
+    buildPackages.haskellPackages.cabal2nix
+
+    # Ideally the above would be sufficient but these are somehow the wrong
+    # derivations. Instead, it's much easier to just cache a simple
+    # test package (tagged in this case.
+    nixpkgs.haskellPackages.tagged
+  ];
+
+  # Get build-time dependencies of a derivation.
+  # See https://github.com/NixOS/nix/issues/1245#issuecomment-401642781
+  getDepends = pkg: let
+    drv = builtins.readFile pkg.drvPath;
+    storeDirRe = lib.replaceStrings [ "." ] [ "\\." ] builtins.storeDir;
+    storeBaseRe = "[0-9a-df-np-sv-z]{32}-[+_?=a-zA-Z0-9-][+_?=.a-zA-Z0-9-]*";
+    re = "(${storeDirRe}/${storeBaseRe}\\.drv)";
+    inputs = lib.concatLists (lib.filter lib.isList (builtins.split re drv));
+  in map import inputs;
+
+  # The packages which we are here to test
+  testedPackages = with nixpkgs.haskell.lib; with nixpkgs.haskellPackages; {
+    inherit lens aeson criterion scotty;
+    # servant: Don't distribute Sphinx documentation
+    servant = overrideCabal servant { postInstall = ""; };
+    # singletons: Disable testsuite since it often breaks due to spurious
+    # TH-pretty-printing changes
+    singletons = dontCheck singletons;
+  };
+
+  inherit (nixpkgs) lib;
+
+  transHaskellDeps = drv:
+    let
+      haskellDeps = drv.passthru.getBuildInputs.haskellBuildInputs or [];
+    in [{
+      haskellDeps = map (dep: dep.name) haskellDeps;
+      drvName = drv.name;
+      drvPath = drv.drvPath;
+      out = drv.outPath;
+      name = drv.passthru.pname;
+      version = drv.passthru.version;
+    }] ++ lib.concatMap transHaskellDeps haskellDeps;
+
+  summary = {
+    pkgs = lib.concatMap transHaskellDeps (lib.attrValues testedPackages);
+    roots = map (drv: drv.name) (lib.attrValues testedPackages);
+  };
+
+  # Find Job ID of the given job name in the given pipeline
+  find-job = nixpkgs.writeScriptBin "find-job.sh" ''
+    set -e
+
+    project_id=$1
+    pipeline_id=$2
+    job_name=$3
+
+    # Access token is a protected environment variable in the head.hackage project and
+    # is necessary for this query to succeed. Sadly job tokens only seem to
+    # give us access to the project being built.
+    ${nixpkgs.curl}/bin/curl \
+      --silent --show-error \
+      -H "Private-Token: $ACCESS_TOKEN" \
+      "https://gitlab.haskell.org/api/v4/projects/$project_id/pipelines/$pipeline_id/jobs?scope[]=success" \
+      > resp.json
+
+    job_id=$(${nixpkgs.jq}/bin/jq ". | map(select(.name == \"$job_name\")) | .[0].id" < resp.json)
+    if [ "$job_id" = "null" ]; then
+      echo "Error finding job $job_name for $pipeline_id in project $project_id:" >&2
+      cat resp.json >&2
+      rm resp.json
+      exit 1
+    else
+      rm resp.json
+      echo -n "$job_id"
+    fi
+  '';
+
+in {
+  inherit nixpkgs ghc testedPackages buildDepends;
+  inherit (nixpkgs) haskellPackages lib;
+  testedPackageNames = nixpkgs.lib.attrNames testedPackages;
+  inherit summary find-job;
+}

--- a/scripts/patch-tool
+++ b/scripts/patch-tool
@@ -98,8 +98,8 @@ usage: $0 MODE ...
 
 Modes:
   unpack-all            unpack and patch all packages with patches
-  unpack \$pkg         unpack the given package into packages/
-  unpack-patch \$pkg   unpack and apply patches to the given package
+  unpack \$pkg           unpack the given package into packages/
+  unpack-patch \$pkg     unpack and apply patches to the given package
   update-patches        update patches for all unpacked packages
   drop-old              drop patches for obsolete package versions
 EOF

--- a/scripts/patch-tool
+++ b/scripts/patch-tool
@@ -38,10 +38,14 @@ add_pkg_dirs() {
 }
 
 patch_pkg() {
+    if [ ! -e "$1" ]; then 
+        echo "No patches for $1; skipping patching."
+        return
+    fi
     local patch=$(basename $1)
     local pkg=$(basename $patch .patch)
     local pkg_dir=packages/$pkg
-    git -C $pkg_dir apply $patches_dir/$patch.patch
+    git -C $pkg_dir apply $patches_dir/$pkg.patch
     git -C $pkg_dir commit -a -m "head.hackage.org patch"
 }
 
@@ -93,8 +97,9 @@ usage() {
 usage: $0 MODE ...
 
 Modes:
-  unpack \$pkg          unpack the given package into packages/
-  unpack-patch \$pkg    unpack and apply patches to the given package
+  unpack-all            unpack and patch all packages with patches
+  unpack \$pkg         unpack the given package into packages/
+  unpack-patch \$pkg   unpack and apply patches to the given package
   update-patches        update patches for all unpacked packages
   drop-old              drop patches for obsolete package versions
 EOF
@@ -110,7 +115,7 @@ case "X$1" in
         ;;
 
     Xunpack-patch)
-        patch=$1
+        patch=$2
         unpack_pkg $(basename $patch .patch)
         patch_pkg $patch
         ;;

--- a/scripts/patch-tool
+++ b/scripts/patch-tool
@@ -39,12 +39,24 @@ add_pkg_dirs() {
 
 patch_pkg() {
     local pkg=$(basename $1 .patch)
+    local pkg_dir=packages/$pkg
     local patch=$patches_dir/$pkg.patch
-    if [ ! -e "$patch" ]; then
-        echo "No patches for $pkg; skipping patching." return
-    else
-        local pkg_dir=packages/$pkg
+    local cabal=$patches_dir/$pkg.cabal
+
+    local patched=
+    if [ -f "$patch" ]; then
+        echo "Applied patch $patch to $pkg"
         git -C $pkg_dir apply $patch
+        patched=1
+    fi
+
+    if [ -f "$cabal" ]; then
+        echo "Updated cabal file of $pkg with $cabal"
+        cp "$cabal" $pkg_dir/*.cabal
+        patched=1
+    fi
+
+    if [ -n "$patched" ]; then
         git -C $pkg_dir commit -q -a -m "head.hackage.org patch"
     fi
 }

--- a/scripts/patch-tool
+++ b/scripts/patch-tool
@@ -33,7 +33,7 @@ drop_old() {
 
 add_pkg_dirs() {
     local dirs=$@
-    echo "packages: $dirs" >> cabal.project.local
+    echo "optional-packages: $dirs" >> cabal.project.local
     echo "Added $dirs to cabal.project.local"
 }
 

--- a/scripts/patch-tool
+++ b/scripts/patch-tool
@@ -57,8 +57,8 @@ unpack_patch_pkg() {
 }
 
 unpack_patch_all() {
-    for p in $patches_dir/*; do
-        patch_pkg $p
+    for p in $patches_dir/*.patch; do
+        unpack_patch_pkg $p
     done
 }
 

--- a/scripts/patch-tool
+++ b/scripts/patch-tool
@@ -45,7 +45,7 @@ patch_pkg() {
     else
         local pkg_dir=packages/$pkg
         git -C $pkg_dir apply $patch
-        git -C $pkg_dir commit -a -m "head.hackage.org patch"
+        git -C $pkg_dir commit -q -a -m "head.hackage.org patch"
     fi
 }
 
@@ -75,7 +75,7 @@ unpack_pkg() {
     cd $pkg_dir
     git init
     git add .
-    git commit -m "Initial commit"
+    git commit -q -m "Initial commit of $pkg"
     git tag upstream
     popd
     add_pkg_dirs packages/$pkg_dir

--- a/scripts/patch-tool
+++ b/scripts/patch-tool
@@ -38,15 +38,15 @@ add_pkg_dirs() {
 }
 
 patch_pkg() {
-    if [ ! -e "$1" ]; then 
-        echo "No patches for $1; skipping patching."
-        return
+    local pkg=$(basename $1 .patch)
+    local patch=$patches_dir/$pkg.patch
+    if [ ! -e "$patch" ]; then
+        echo "No patches for $pkg; skipping patching." return
+    else
+        local pkg_dir=packages/$pkg
+        git -C $pkg_dir apply $patch
+        git -C $pkg_dir commit -a -m "head.hackage.org patch"
     fi
-    local patch=$(basename $1)
-    local pkg=$(basename $patch .patch)
-    local pkg_dir=packages/$pkg
-    git -C $pkg_dir apply $patches_dir/$pkg.patch
-    git -C $pkg_dir commit -a -m "head.hackage.org patch"
 }
 
 unpack_patch_pkg() {

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p python3 -i python3
+
+import os
+from pathlib import Path
+import subprocess
+import json
+
+def read_summary():
+    summary = subprocess.check_output(
+        ['nix', 'eval', '--json',
+         '--arg', 'bindistTarball', os.environ['GHC_TARBALL'],
+         '-f', 'scripts/build-all.nix',
+         'summary'],
+        encoding = 'UTF-8')
+
+    summary = json.loads(summary)
+    for pkg in summary['pkgs']:
+        pkg['failed'] = not Path(pkg['out']).exists()
+        del pkg['out']
+
+    return summary
+
+def export_logs(summary):
+    logs = Path('logs')
+    logs.mkdir(exist_ok=True)
+    # Deduplicate
+    pkgs = { pkg['drvPath']: pkg for pkg in summary['pkgs'] }
+    for pkg in pkgs.values():
+        print(f'Collecting log for {pkg["drvPath"]}...')
+        p = subprocess.run(['nix', 'log', pkg['drvPath']],
+                           stdout=open(logs / f'{pkg["drvName"]}.log', 'wb'))
+        if p.returncode != 0:
+            print(f'Error exporting log for {pkg["drvPath"]}')
+
+def export_dot(summary):
+    pkgsDict = { pkg['drvName']: pkg for pkg in summary['pkgs'] }
+    edges = {
+        (pkg['drvName'], dep)
+        for pkg in summary['pkgs']
+        for dep in pkg['haskellDeps']
+    }
+
+    s = 'digraph {\n'
+    s += '  {overlap=prism};\n'
+
+    s += '  subgraph cluster_roots {\n'
+    s += '    {fillcolor=blue style=filled};\n'
+    for pkg in summary['roots']:
+        s += f'    "{pkg}";\n'
+    s += '  }\n'
+    s += '\n'
+
+    for pkg, dep in edges:
+        s +=  f'  "{pkg}" -> "{dep}";\n'
+
+    for pkg in summary['pkgs']:
+        if pkg['failed']:
+            s += f'  "{pkg["drvName"]}" [ color=indianred style=filled ];\n'
+
+    s += '}'
+    return s
+
+def show_failures(summary, log_excerpt=100):
+    failed = [pkg
+              for pkg in summary['pkgs']
+              if pkg['failed']]
+    if len(failed) == 0:
+        print('='*80)
+        print('No issues encountered.')
+        print('='*80)
+    else:
+        print('='*80)
+        print('These packages failed to build:')
+        print()
+        for pkg in failed:
+            print('*', pkg['name'])
+            print()
+            proc = subprocess.run(['nix', 'log', pkg['drvPath']],
+                                 stdout=subprocess.PIPE,
+                                 encoding='UTF-8')
+            if proc.returncode != 0:
+                print(f'    Error: Failed to fetch log')
+                continue
+
+            print(f'  ---- Last {log_excerpt} lines of log follow ----')
+            lines = proc.stdout.split('\n')
+            if len(lines) > log_excerpt:
+                print('    ⋮')
+
+            print('\n    '.join(lines[-log_excerpt:]))
+            print('  ---- End of log ----------------------------')
+            print()
+            print()
+
+        print('='*80)
+
+if __name__ == "__main__":
+    assert os.environ['GHC_TARBALL'] != None
+    summary = read_summary()
+    export_logs(summary)
+    json.dump(summary, Path('summary.json').open('w'))
+    show_failures(summary)
+    Path('summary.dot').write_text(export_dot(summary))


### PR DESCRIPTION
This merges the Nix-based CI infrastructure used by [gitlab.haskell.org](https://gitlab.haskell.org/ghc/head.hackage) upstream.

This depends upon #114 and also includes #113, although does not require it, per se.
