### PR TITLE
Adapt singletons-2.5.1 patch to GHC commit 4ba73e00

### DIFF
--- a/patches/singletons-2.5.1.patch
+++ b/patches/singletons-2.5.1.patch
@@ -1,3 +1,22 @@
+commit ea5787091689e857ea7c71a89ac2823644e493bd
+Author: Matthew Bauer <mjbauer95@gmail.com>
+Date:   Thu Apr 25 08:54:33 2019 -0400
+
+    Use fromintegral to avoid GHCJS conflict (#389)
+
+diff --git a/src/Data/Singletons/Util.hs b/src/Data/Singletons/Util.hs
+index e45865d..38104e2 100644
+--- a/src/Data/Singletons/Util.hs
++++ b/src/Data/Singletons/Util.hs
+@@ -96,7 +96,7 @@ qNewUnique :: DsMonad q => q Int
+ qNewUnique = do
+   Name _ flav <- qNewName "x"
+   case flav of
+-    NameU n -> return n
++    NameU n -> return $ fromIntegral n
+     _       -> error "Internal error: `qNewName` didn't return a NameU"
+ 
+ checkForRep :: Quasi q => [Name] -> q ()
 commit a78a74fefdcb9b31f2c2a50b2aa015f862a7bdf8
 Author: Ryan Scott <ryan.gl.scott@gmail.com>
 Date:   Fri Mar 15 19:26:47 2019 -0400


### PR DESCRIPTION
https://gitlab.haskell.org/ghc/ghc/commit/4ba73e00c4887b58d85131601a15d00608acaa60 changed the type of `Uniq` (in `template-haskell`) from `Int` to `Integer`, which breaks `singletons`. This work around the change accordingly with `fromIntegral`.

Patch taken from goldfirere/singletons#389.